### PR TITLE
写真投稿機能

### DIFF
--- a/app/Bookdata.php
+++ b/app/Bookdata.php
@@ -9,6 +9,7 @@ class Bookdata extends Model
   protected $table = 'bookdata';
   protected $guarded = array('id');
   public static $rules = array(
-    'title' => 'required'
+    'title' => 'required',
+    'picture' => 'required|file|image|mimes:jpeg,png,jpg,gif|max:2048'
   );
 }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -40,6 +40,7 @@ class BookController extends Controller
       $form = $request->all();
       unset($form['_token']);
       $book->fill($form)->save();
+      $request->picture->storeAs('public/book_images', $book->id . '.jpg');
       return redirect('/book');
     }
 

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -16,9 +16,15 @@
 .index-content .books-list .book-table tr:hover {
   background: #eee;
 }
-.index-content .books-list .book-table td {
+.index-content .books-list .book-table th {
   height: 90px;
   line-height: 90px;
+  border: 1px solid #bbb;
+  background: #fff;
+  z-index: 2;
+}
+.index-content .books-list .book-table td {
+  height: 90px;
   text-align: center;
   border: 1px solid #bbb;
 }
@@ -27,8 +33,12 @@
   background: #f4f4fd;
 }
 .index-content .books-list .book-table td:nth-of-type(2) {
-  width: 50px;
+  width: 165px;
 }
 .index-content .books-list .book-table td:nth-of-type(3) {
   width: 500px;
+}
+.index-content .books-list .book-table td img {
+  height: 90px;
+  background-size: contain;
 }

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -15,9 +15,16 @@
           background: #eeeeee;
         }
       }
-      td {
+      th {
         height: 90px;
         line-height: 90px;
+        border: 1px solid #bbb;
+        background: #ffffff;
+        z-index: 2;
+      }
+      td {
+        height: 90px;
+        // line-height: 90px;
         text-align: center;
         border: 1px solid #bbb;
         &:first-child {
@@ -25,10 +32,14 @@
           background: #f4f4fd;
         }
         &:nth-of-type(2) {
-          width: 50px;
+          width: 165px;
         }
         &:nth-of-type(3) {
           width: 500px;
+        }
+        img {
+          height: 90px;
+          background-size: contain;
         }
       }
     }

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -12,11 +12,11 @@
     <!-- サイドバー(コンポーネント) -->
     @component('components.sidebar')
     @endcomponent
-    <form action="/book" method="post" class="book-form">
+    <form action="/book" method="post" class="book-form" enctype="multipart/form-data" >
       {{ csrf_field() }}
       <table>
       <tr><th>タイトル</th><td><input type="text" name="title" value="{{old('title')}}"></td></tr>
-      <tr><th>写真</th><td><input type="text" name="picture" value="{{old('picture')}}"></td></tr>
+      <tr><th>写真</th><td><input type="file" name="picture" value="{{old('picture')}}"></td></tr>
       <tr><th></th><td><input type="submit" value="send"></td></tr>
       </table>
     </form>

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -19,17 +19,17 @@
       <div class="book-table">
         <table class="book-table__list">
           <tr>
-            <td>id</td>
-            <td>写真</td>
-            <td>タイトル</td>
-            <td>登録日</td>
+            <th>id</th>
+            <th>写真</th>
+            <th>タイトル</th>
+            <th>登録日</th>
           </tr>
           @foreach ($books as $book)
           <tr>
             <td>{{$book->id}}</td>
-            <td>{{$book->picture}}</td>
+            <td><img src="/storage/book_images/{{$book->id}}.jpg"></td>
             <td><a href="/book/{{$book->id}}">{{$book->title}}</a></td>
-            <td>{{$book->created_at}}</td>
+            <td>{{$book->created_at->format('y/m/d')}}</td>
           </tr>
           @endforeach
         </table>


### PR DESCRIPTION
#WHAT
写真をstorageディレクトリへ保存しindexビューで表示させる状態にする。
## モデル、バリデーション設定項目変更
app/Bookdata.php
## コントローラ、画像保存設定を追加
app/Http/Controllers/BookController.php
## ビュー表示設定変更
public/css/book-index.css
public/scss/book-index.scss
resources/views/book/create.blade.php
resources/views/book/index.blade.php

#WHY
新規登録時のpictureをテキストからファイル選択形式に変更。
画像ファイルはstorageディレクトリ以下へ保存。
indexにて保存画像を表示する形式へ変更。

## 表示イメージ 2/2
1.ファイル選択表示
<img width="691" alt="スクリーンショット 2019-03-20 16 55 42" src="https://user-images.githubusercontent.com/45278393/54667997-2489c480-4b31-11e9-837d-4e62cd984008.png">
2.index画像反映
<img width="1135" alt="スクリーンショット 2019-03-20 16 55 54" src="https://user-images.githubusercontent.com/45278393/54668003-2784b500-4b31-11e9-8995-e8b04661b5f4.png">
