### PR TITLE
book情報変更処理

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -43,8 +43,9 @@ class BookController extends Controller
       // フォームトークン削除
       unset($form['_token']);
       // 画像データ情報取得
-      $file = $request->file('picture');
       if (isset($form['picture'])) {
+        // 画像情報取得
+        $file = $request->file('picture');
         // 拡張子取得
         $ext = $file->getClientOriginalExtension();
         // ファイル保存用トークン発行
@@ -97,6 +98,42 @@ class BookController extends Controller
       $book = Bookdata::find($id);
       $form = $request->all();
       unset($form['_token']);
+
+      // フォーム画像情報取得
+      // 変更なければ処理なし
+      // 変更あり・削除時に削除処理
+      // 変更時に新データアップロード
+
+      // 画像アップロード処理
+      // eval(\Psy\sh());
+      if (isset($form['picture'])) {
+        // 写真削除処理
+        if ($form['picture'] == "no-picture") {
+          // 削除写真名取得
+          $deletename = $book->picture;
+          // 写真削除
+          $pathdel = storage_path() . '/app/public/book_images/' . $deletename;
+          \File::delete($pathdel);
+          // レコード更新処理
+          $form['picture'] = null;
+        } else {
+          // 写真追加処理
+          // 画像情報取得
+          $file = $request->file('picture');
+          // 拡張子取得
+          $ext = $file->getClientOriginalExtension();
+          // ファイル保存用トークン発行
+          $file_token = str_random(32);
+          // 画像ファイル名作成
+          $pictureFile = $file_token . "." . $ext;
+          // 画像ファイル名指定
+          $form['picture'] = $pictureFile;
+          // 画像ファイルをstorage保存
+          $request->picture->storeAs('public/book_images', $pictureFile);
+        }
+      }
+
+      // レコードアップデート
       $book->fill($form)->save();
       return redirect('/book');
     }

--- a/public/js/update_book.js
+++ b/public/js/update_book.js
@@ -1,0 +1,33 @@
+$(function() {
+  // タイトル名更新
+  $(".book-title").on("keyup", function() {
+    var title_text = $(this).val();
+    if (title_text.length == 0) {
+      $('.aftertitle').html("<span class='alert_title'>タイトルを入力して下さい。</span>");
+    } else {
+      $('.aftertitle').html(title_text);
+    }
+  });
+
+  // 画像処理
+
+  // アップロードするファイルを選択
+  $('input[type=file]').change(function() {
+    var file = $(this).prop('files')[0];
+    // 画像以外は処理を停止
+    if (! file.type.match('image.*')) {
+      // クリア
+      $(this).val('');
+      $('.afterimage').html('');
+      return;
+    }
+
+    // 画像表示
+    var reader = new FileReader();
+    reader.onload = function() {
+      var img_src = $('<img width="100px">').attr('src', reader.result);
+      $('.afterimage').html(img_src);
+    }
+    reader.readAsDataURL(file);
+  });
+});

--- a/public/js/update_book.js
+++ b/public/js/update_book.js
@@ -9,8 +9,13 @@ $(function() {
     }
   });
 
-  // 画像処理
-
+  // --画像処理--
+  // 画像削除
+  $(".delete-picture").click(function() {
+    $('.delete-picture').after("<input type='hidden' id='no-picture' name='picture' value='no-picture'>");
+    $('.afterimage').html("No Image");
+  });
+  // 画像追加処理
   // アップロードするファイルを選択
   $('input[type=file]').change(function() {
     var file = $(this).prop('files')[0];
@@ -29,5 +34,7 @@ $(function() {
       $('.afterimage').html(img_src);
     }
     reader.readAsDataURL(file);
+    // 削除フラグがある場合は解除
+    $('#no-picture').remove();
   });
 });

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -12,7 +12,7 @@
     <!-- サイドバー(コンポーネント) -->
     @component('components.sidebar')
     @endcomponent
-    <form action="/book" method="post" class="book-form" enctype="multipart/form-data" >
+    <form action="/book" method="post" class="book-form" enctype="multipart/form-data">
       {{ csrf_field() }}
       <table>
       <tr><th>タイトル</th><td><input type="text" name="title" value="{{old('title')}}"></td></tr>

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -22,6 +22,7 @@
         <input type="hidden" name="_method" value="PUT">
         <tr><th>タイトル</th><td><input type="text" name="title" value="{{$form->title}}" class="book-title"></td></tr>
         <tr><th>写真</th><td><input type="file" name="picture" value="{{$form->picture}}"></td></tr>
+        <tr><th>写真削除</th><td><input type="button" name="delete" value="削除" class="delete-picture"></td></tr>
         <tr><th></th><td><input type="submit" value="send"></td></tr>
         </table>
       </form>
@@ -34,28 +35,13 @@
           <div class="book-table">
             <table class="book-table__list">
               <tr>
-                <th>a</th>
-                <th>id</th>
+                <th></th>
                 <th>写真</th>
                 <th>タイトル</th>
                 <th>登録日</th>
               </tr>
               <tr>
-                <td>編集前</td>
-                <td>{{$form->id}}</td>
-                <td>
-                  @if (isset($form->picture))
-                    <img src="/storage/book_images/{{$form->picture}}" width="100px">
-                  @else
-                    No Image
-                  @endif
-                </td>
-                <td><a href="/book/{{$form->id}}">{{$form->title}}</a></td>
-                <td>{{$form->created_at->format('y/m/d')}}</td>
-              </tr>
-              <tr>
                 <td>編集後</td>
-                <td>{{$form->id}}</td>
                 <td class="afterimage">
                   @if (isset($form->picture))
                     <img src="/storage/book_images/{{$form->picture}}" width="100px">
@@ -64,6 +50,18 @@
                   @endif
                 </td>
                 <td class="aftertitle">{{$form->title}}</td>
+                <td>{{$form->created_at->format('y/m/d')}}</td>
+              </tr>
+              <tr>
+                <td>編集前</td>
+                <td>
+                  @if (isset($form->picture))
+                    <img src="/storage/book_images/{{$form->picture}}" width="100px">
+                  @else
+                    No Image
+                  @endif
+                </td>
+                <td><a href="/book/{{$form->id}}">{{$form->title}}</a></td>
                 <td>{{$form->created_at->format('y/m/d')}}</td>
               </tr>
             </table>

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -3,8 +3,11 @@
 @section('title', 'EditForm')
 
 @section('stylesheet')
+  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="/js/update_book.js" type="text/javascript" charset="UTF-8"></script>
   <link href="/css/sidebar.css" rel="stylesheet" type="text/css">
   <link href="/css/book-form.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 
 @section('content')
@@ -12,14 +15,62 @@
     <!-- サイドバー(コンポーネント) -->
     @component('components.sidebar')
     @endcomponent
-    <form action="/book/{{$form->id}}" method="post" class="book-form">
-      {{ csrf_field() }}
-      <table>
-      <input type="hidden" name="_method" value="PUT">
-      <tr><th>タイトル</th><td><input type="text" name="title" value="{{$form->title}}"></td></tr>
-      <tr><th>写真</th><td><input type="text" name="picture" value="{{$form->picture}}"></td></tr>
-      <tr><th></th><td><input type="submit" value="send"></td></tr>
-      </table>
-    </form>
+    <div>
+      <form action="/book/{{$form->id}}" method="post" class="book-form" enctype="multipart/form-data">
+        {{ csrf_field() }}
+        <table>
+        <input type="hidden" name="_method" value="PUT">
+        <tr><th>タイトル</th><td><input type="text" name="title" value="{{$form->title}}" class="book-title"></td></tr>
+        <tr><th>写真</th><td><input type="file" name="picture" value="{{$form->picture}}"></td></tr>
+        <tr><th></th><td><input type="submit" value="send"></td></tr>
+        </table>
+      </form>
+      <div class="index-content">
+      <!-- <div> -->
+        <div class="books-list">
+          <div class="books-list__title">
+            編集のイメージ
+          </div>
+          <div class="book-table">
+            <table class="book-table__list">
+              <tr>
+                <th>a</th>
+                <th>id</th>
+                <th>写真</th>
+                <th>タイトル</th>
+                <th>登録日</th>
+              </tr>
+              <tr>
+                <td>編集前</td>
+                <td>{{$form->id}}</td>
+                <td>
+                  @if (isset($form->picture))
+                    <img src="/storage/book_images/{{$form->picture}}" width="100px">
+                  @else
+                    No Image
+                  @endif
+                </td>
+                <td><a href="/book/{{$form->id}}">{{$form->title}}</a></td>
+                <td>{{$form->created_at->format('y/m/d')}}</td>
+              </tr>
+              <tr>
+                <td>編集後</td>
+                <td>{{$form->id}}</td>
+                <td class="afterimage">
+                  @if (isset($form->picture))
+                    <img src="/storage/book_images/{{$form->picture}}" width="100px">
+                  @else
+                    No Image
+                  @endif
+                </td>
+                <td class="aftertitle">{{$form->title}}</td>
+                <td>{{$form->created_at->format('y/m/d')}}</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
+
 @endsection


### PR DESCRIPTION
#WHAT
book情報変更処理を実装
## コントローラ、写真のみ削除時の処理を追加
app/Http/Controllers/BookController.php
## book情報編集時の結果をビューに即時反映、タイトル・画像処理
public/js/update_book.js
## 新規作成ビュー修正
resources/views/book/create.blade.php
## 編集ビュー、JS適用、編集後イメージ表示
resources/views/book/edit.blade.php

#WHY
book編集における不足点をカバー
## JS実装について
編集後のイメージをリアルタイムに表示させる為に実装
### JS処理実施内容
タイトル名を入力することで、変更後イメージにタイトル名を即時反映させるようにした。なお、タイトル名を空欄にするとアラート表示させるようにしている。
画像追加時は、ファイルの種類を判定し、画像でない場合は処理を中止、また中止時に変更後の画像表示を解除するようにした。
画像選択完了後、画像イメージを即時反映させるようにした。
画像表示処理に暫定的にwidthサイズを入れている。
レイアウトは別ブランチでまとめて修正予定。
画像削除時は変更後画像を削除するようにした。
## 画像について
アップロードすることにおいて画像変更は可能であったが、他の処理ができなかった為、変更を加えた。
### 画像処理実施内容
画像のみ削除、画像変更時に古い画像を削除することに対応。
編集フォームにて画像削除ボタンを押下することで、JSによって削除情報が付加され、sendすることで削除処理を行う。
## ビューファイルについて
JSを適用するための設定追加及びJQueryを使用するための設定を追加。
変更後イメージを全データ表示フォームを暫定的に利用して表示しているため、併せてスタイルシート設定を追加している。
# 表示イメージ
<img width="1056" alt="スクリーンショット 2019-03-22 15 42 28" src="https://user-images.githubusercontent.com/45278393/54805096-35654200-4cb9-11e9-92e2-d4c78c11dd17.png">
