### PR TITLE
S3アップロード画像の削除処理

### DIFF
--- a/app/Helpers/picture_helpers.php
+++ b/app/Helpers/picture_helpers.php
@@ -34,22 +34,43 @@ function s3settings(){
 function picture_upload($directory,$name,$tmp_name,$ext,$s3) {
   //読み込みの際のキーとなるS3上のファイルパスを作る
   $tmp_replace_name = str_replace('/tmp/','',$tmp_name);
-  $new_filename = $directory.'/'.$tmp_replace_name.'.'.$ext;
+  $new_filename = $directory.$tmp_replace_name.'.'.$ext;
   //アップロードするファイルを用意
   $image = fopen($tmp_name,'rb');
   //S3画像のアップロード
   $result = $s3["s3client"]->putObject([
-      'ACL' => 'public-read',
-      'Bucket' => $s3["bucket"],
-      'Key' => $new_filename,
-      'Body' => $image,
-      'ContentType' => mime_content_type($tmp_name),
+    'ACL' => 'public-read',
+    'Bucket' => $s3["bucket"],
+    'Key' => $new_filename,
+    'Body' => $image,
+    'ContentType' => mime_content_type($tmp_name),
   ]);
+  // eval(\Psy\sh());
   // 画像読み取り用のパスを返す
   $path = $result['ObjectURL'];
   return $path;
 }
 
-function picture_delete() {
+function picture_delete($directory,$book,$s3) {
+  // eval(\Psy\sh());
+  // 削除用キー生成
+  $book_pass = $book["picture"];// DB保存パス
+  $bucket = $s3["bucket"];//バケット名
+  $region = env('AWS_DEFAULT_REGION');//リージョン名
+  $delete_pass = "{.*".$bucket.".s3.".$region.".amazonaws.com/}";//削除テキスト生成
+  //$delete_passを含む先頭からの文字をDB保存パスから削除する
+  // $delete_key = preg_replace("{.*fippiy.s3.ap-northeast-1.amazonaws.com/}", "", $book_pass);
+  $delete_key = preg_replace("$delete_pass", "", $book_pass);
+  // eval(\Psy\sh());
+
+  // $delete_key = ;// 削除キー
+
+    // 'Key' => "book_images/private/var/folders/x2/96c_zgys1yvfp4905c063n_80000gn/T/phpJ8TnBx.jpg"
+
+  $result = $s3["s3client"]->deleteObject([
+    'Bucket' => $s3["bucket"],
+    'Key' => $delete_key
+  ]);
+  // eval(\Psy\sh());
 
 }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -61,8 +61,8 @@ class BookController extends Controller
         if ( app()->isLocal() || app()->runningUnitTests() ) {
         // if ( app()->runningUnitTests() ) {
           // ローカル保存処理
-          $request->picture->storeAs('public/'.$save_directory, $picture_name.".".$picture_ext); // 画像ファイルをstorage保存
-          $picture_upload = "/storage/".$save_directory."/".$picture_name.".".$picture_ext; //画像保存パス
+          $request->picture->storeAs('public/'.$save_directory, $picture_name); // 画像ファイルをstorage保存
+          $picture_upload = "/storage/".$save_directory."/".$picture_name; //画像保存パス
 
         } else {
           // 本番環境保存処理
@@ -158,10 +158,13 @@ class BookController extends Controller
      */
     public function destroy($id)
     {
+      // 画像保存ディレクトリ設定
+      $save_directory = "book_images";
       // 削除レコード取得
       $deleteBook = Bookdata::find($id);
       // 写真削除情報取得
-      $deletename = $deleteBook->picture;
+      $deletename = str_replace('/storage/'.$save_directory.'/','',$deleteBook->picture);
+
       $pathdel = storage_path() . '/app/public/book_images/' . $deletename;
       // 写真削除
       \File::delete($pathdel);

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -59,7 +59,7 @@ class BookController extends Controller
 
         // 開発環境で画像保存先を変更
         if ( app()->isLocal() || app()->runningUnitTests() ) {
-        // if ( app()->runningUnitTests() ) {
+        // if ( app()->runningUnitTests() ) {g
           // ローカル保存処理
           $request->picture->storeAs('public/'.$save_directory, $picture_name); // 画像ファイルをstorage保存
           $picture_upload = "/storage/".$save_directory."/".$picture_name; //画像保存パス
@@ -161,9 +161,9 @@ class BookController extends Controller
       // 画像保存ディレクトリ設定
       $save_directory = "book_images";
       // 削除レコード取得
-      $deleteBook = Bookdata::find($id);
+      $delete_book = Bookdata::find($id);
       // 写真削除情報取得
-      $deletename = str_replace('/storage/'.$save_directory.'/','',$deleteBook->picture);
+      $deletename = str_replace('/storage/'.$save_directory.'/','',$delete_book->picture);
 
       $pathdel = storage_path() . '/app/public/book_images/' . $deletename;
       // 写真削除

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -58,8 +58,8 @@ class BookController extends Controller
         picture_check($picture_ext,$picture_error);
 
         // 開発環境で画像保存先を変更
-        if ( app()->isLocal() || app()->runningUnitTests() ) {
-        // if ( app()->runningUnitTests() ) {g
+        // if ( app()->isLocal() || app()->runningUnitTests() ) {
+        if ( app()->runningUnitTests() ) {
           // ローカル保存処理
           $request->picture->storeAs('public/'.$save_directory, $picture_name); // 画像ファイルをstorage保存
           $picture_upload = "/storage/".$save_directory."/".$picture_name; //画像保存パス
@@ -162,14 +162,26 @@ class BookController extends Controller
       $save_directory = "book_images";
       // 削除レコード取得
       $delete_book = Bookdata::find($id);
-      // 写真削除情報取得
-      $deletename = str_replace('/storage/'.$save_directory.'/','',$delete_book->picture);
+      // 開発環境で画像保存先を変更
+      // if ( app()->isLocal() || app()->runningUnitTests() ) {
+      if ( app()->runningUnitTests() ) {
 
-      $pathdel = storage_path() . '/app/public/book_images/' . $deletename;
-      // 写真削除
-      \File::delete($pathdel);
+        // 写真削除情報取得
+        $deletename = str_replace('/storage/'.$save_directory.'/','',$delete_book->picture);
+
+        $pathdel = storage_path() . '/app/public/book_images/' . $deletename;
+        // 写真削除
+        \File::delete($pathdel);
+      } else {
+        // 本番環境削除処理
+        // S3インスタンス生成
+        $s3settings = s3settings();
+        // S3削除処理
+        $picture_delete = picture_delete($save_directory,$delete_book,$s3settings);
+      }
+      // eval(\Psy\sh());
       // レコード削除
-      $deleteBook->delete();
+      $delete_book->delete();
       return redirect('/book');
     }
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -58,8 +58,7 @@ class BookController extends Controller
         picture_check($picture_ext,$picture_error);
 
         // 開発環境で画像保存先を変更
-        // if ( app()->isLocal() || app()->runningUnitTests() ) {
-        if ( app()->runningUnitTests() ) {
+        if ( app()->isLocal() || app()->runningUnitTests() ) {
           // ローカル保存処理
           $request->picture->storeAs('public/'.$save_directory, $picture_name); // 画像ファイルをstorage保存
           $picture_upload = "/storage/".$save_directory."/".$picture_name; //画像保存パス
@@ -163,9 +162,7 @@ class BookController extends Controller
       // 削除レコード取得
       $delete_book = Bookdata::find($id);
       // 開発環境で画像保存先を変更
-      // if ( app()->isLocal() || app()->runningUnitTests() ) {
-      if ( app()->runningUnitTests() ) {
-
+      if ( app()->isLocal() || app()->runningUnitTests() ) {
         // 写真削除情報取得
         $deletename = str_replace('/storage/'.$save_directory.'/','',$delete_book->picture);
 
@@ -179,7 +176,6 @@ class BookController extends Controller
         // S3削除処理
         $picture_delete = picture_delete($save_directory,$delete_book,$s3settings);
       }
-      // eval(\Psy\sh());
       // レコード削除
       $delete_book->delete();
       return redirect('/book');


### PR DESCRIPTION
# WHAT
bookレコード削除時にS3にアップロードした画像も併せて削除できるようにする
## 画像用ヘルパー、削除処理追加、region取得変数の共通化
app/Helpers/picture_helpers.php
## コントローラ、削除処理追加
app/Http/Controllers/BookController.php

# WHY
## 開発環境処理
画像ファイル拡張子が重複していた為、コード記述を修正
DB保存名がファイル名からURLに変更となっており、正しく消去できなくなっていたので、削除時の指定キーを修正。
## 本番環境処理
今後の編集処理も考え、削除共通処理はヘルパーに記載
S3リージョン名にについて、インスタンス生成時と削除処理時に必要とした為、インスタンス生成時に変数として宣言し、削除処理時に変数を使い回す形として記述変更を実施した。
このため、インスタンス生成時に引き渡す変数が追加されている。
$new_filenameについてアドレスが"//"となっていた為、アドレスを修正
画像削除処理時に画像URLから削除キーを生成する為にreplace処理を行う。
replace処理アドレスはbucket,region参照して生成できるようにし、httpについてもsslに対応させる為、明記せず先頭から"〜.com"までを消去する形として作成。
