### PR TITLE
book-detailレイアウト設定

### DIFF
--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -3,11 +3,34 @@
 }
 .index-content .books-list {
   margin: 0 auto;
-  width: 80%;
+  width: calc(90% - 250px);
 }
 .index-content .books-list__title {
   font-size: 22px;
   padding: 5px 10px;
+  background: #5ba5c8;
+  border-radius: 15px;
+  display: flex;
+  justify-content: space-between;
+}
+.index-content .books-list__title--navigation {
+  display: flex;
+}
+.index-content .books-list__title--navigation .nav-btn {
+  background: white;
+  font-size: 15px;
+  height: 20px;
+  border-radius: 5px;
+  padding: 3px;
+  line-height: 20px;
+  margin: 0 5px 0;
+}
+.index-content .books-list__title--navigation .edit {
+  color: blue;
+}
+.index-content .books-list__title--navigation .delete {
+  color: red;
+  height: 27px;
 }
 .index-content .books-list .book-find {
   width: 800px;
@@ -62,4 +85,19 @@
 .index-content .books-list .book-table__list--detail .book-title {
   font-size: 20px;
   color: blue;
+}
+.index-content .books-list .book-detail {
+  width: 100%;
+  display: flex;
+  margin-top: 15px;
+}
+.index-content .books-list .book-detail__picture img {
+  height: 200px;
+  width: 200px;
+}
+.index-content .books-list .book-detail__document {
+  padding: 10px;
+}
+.index-content .books-list .book-detail__document--title {
+  font-size: 30px;
 }

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -2,10 +2,33 @@
   display: flex;
   .books-list {
     margin: 0 auto;
-    width: 80%;
+    width: calc(90% - 250px);
     &__title {
       font-size: 22px;
       padding: 5px 10px;
+      background: #5ba5c8;
+      border-radius: 15px;
+        display: flex;
+        justify-content: space-between;
+      &--navigation {
+        display: flex;
+        .nav-btn {
+          background: white;
+          font-size: 15px;
+          height: 20px;
+          border-radius: 5px;
+          padding: 3px;
+          line-height: 20px;
+          margin: 0 5px 0;
+        }
+        .edit {
+          color: blue;
+        }
+        .delete {
+          color: red;
+          height: 27px;
+        }
+      }
     }
     .book-find {
       width: 800px;
@@ -61,6 +84,23 @@
             font-size: 20px;
             color: blue;
           }
+        }
+      }
+    }
+    .book-detail {
+      width: 100%;
+      display: flex;
+      margin-top: 15px;
+      &__picture{
+        img {
+          height: 200px;
+          width: 200px;
+        }
+      }
+      &__document {
+        padding: 10px;
+        &--title {
+          font-size: 30px;
         }
       }
     }

--- a/resources/views/book/show.blade.php
+++ b/resources/views/book/show.blade.php
@@ -15,35 +15,27 @@
     <div class="books-list">
       <div class="books-list__title">
         詳細ページ
+        <div class="books-list__title--navigation">
+          <a href="/book/{{$book->id}}/edit" class="nav-btn edit">編集</a>
+          <form action="/book/{{$book->id}}" method="post">
+            {{ csrf_field() }}
+            <input type="hidden" name="_method" value="DELETE">
+            <input type="submit" class="nav-btn delete" value="削除">
+          </form>
+        </div>
       </div>
-      <div class="book-table">
-        <table class="book-table__list">
-          <tr>
-            <td>id</td>
-            <td>写真</td>
-            <td>タイトル</td>
-            <td>登録日</td>
-          </tr>
-          <tr>
-            <td>{{$book->id}}</td>
-            <td>
-              @if (isset($book->picture))
-                <img src="{{$book->picture}}">
-              @else
-                No Image
-              @endif
-            </td>
-            <td>{{$book->title}}</td>
-            <td>{{$book->created_at}}</td>
-          </tr>
-        </table>
+      <div class="book-detail">
+        <div class="book-detail__picture">
+          @if (isset($book->picture))
+            <img src="{{$book->picture}}">
+          @else
+            No Image
+          @endif
+        </div>
+        <div class="book-detail__document">
+          <h3 class="book-detail__document--title">{{$book->title}}</h3>
+        </div>
       </div>
-      <a href="/book/{{$book->id}}/edit">編集</a>
-      <form action="/book/{{$book->id}}" method="post">
-        {{ csrf_field() }}
-        <input type="hidden" name="_method" value="DELETE">
-        <input type="submit" value="削除">
-      </form>
     </div>
   </div>
 @endsection


### PR DESCRIPTION
# WHAT
book詳細画面についてレイアウトを再設計する。

# WHY
book一覧表示を流用してとりあえず表示だけしていたので、表示方法を変更する。
画面左側へ本のイメージ表示に変更。
画面左側に本のタイトルを文字大きさを変更して表示。
タイトル下へは今後の予定で詳細内容を表示する予定。
表示ページタイトルに背景色を追加、詳細内容画面ではさらに右側に編集と削除ボタンを追加。
<img width="1416" alt="スクリーンショット 2019-04-01 12 40 07" src="https://user-images.githubusercontent.com/45278393/55302278-67299600-547b-11e9-9791-bed21937c11a.png">
