### PR TITLE
新規投稿ページスタイル修正

### DIFF
--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -101,3 +101,57 @@
 .index-content .books-list .book-detail__document--title {
   font-size: 30px;
 }
+.index-content .books-list .book-new {
+  margin-top: 20px;
+}
+.index-content .books-list .book-new .form-contents {
+  display: flex;
+}
+.index-content .books-list .book-new .form-contents .form-left {
+  width: 30%;
+}
+.index-content .books-list .book-new .form-contents .form-right {
+  width: 60%;
+}
+.index-content .books-list .book-new .form-contents .form-foot {
+  margin: 0 auto;
+  width: 100%;
+}
+.index-content .books-list .book-new .form-contents .form-label {
+  font-size: 25px;
+}
+.index-content .books-list .book-new .form-contents .form-input {
+  margin: 10px 0;
+}
+.index-content .books-list .book-new .form-contents .form-input__title {
+  width: 100%;
+  height: 40px;
+  font-size: 20px;
+  border-radius: 15px;
+  padding: 3px 8px;
+}
+.index-content .books-list .book-new .form-contents .form-input__detail {
+  width: 100%;
+  height: 160px;
+  font-size: 15px;
+  border-radius: 15px;
+  padding: 3px 8px;
+}
+.index-content .books-list .book-new .form-contents .form-input__picture {
+  background: #efefef;
+  margin: 8px;
+}
+.index-content .books-list .book-new .form-contents .form-input__picture img {
+  width: 300px;
+  height: 300px;
+}
+.index-content .books-list .book-new .form-contents .form-input__picture--text {
+  line-height: 300px;
+}
+.index-content .books-list .book-new .form-foot .send {
+  height: 30px;
+  width: 100%;
+  background: #080;
+  color: #fff;
+  font-size: 18px;
+}

--- a/public/js/update_book.js
+++ b/public/js/update_book.js
@@ -30,7 +30,7 @@ $(function() {
     // 画像表示
     var reader = new FileReader();
     reader.onload = function() {
-      var img_src = $('<img width="100px">').attr('src', reader.result);
+      var img_src = $('<img class="">').attr('src', reader.result);
       $('.afterimage').html(img_src);
     }
     reader.readAsDataURL(file);

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -104,5 +104,64 @@
         }
       }
     }
+    .book-new {
+      margin-top: 20px;
+      .form-contents {
+        display: flex;
+        .form-left {
+          width: 30%;
+        }
+        .form-right {
+          width: 60%;
+        }
+        .form-foot {
+          margin: 0 auto;
+          width: 100%;
+        }
+        .form-label {
+          font-size: 25px;
+        }
+        .form-input {
+          margin: 10px 0;
+          &__title {
+            width: 100%;
+            height: 40px;
+            font-size: 20px;
+            border-radius: 15px;
+            padding: 3px 8px;
+          }
+          &__detail {
+            width: 100%;
+            height: 160px;
+            font-size: 15px;
+            border-radius: 15px;
+            padding: 3px 8px;
+          }
+          &__picture {
+            background: #efefef;
+            margin: 8px;
+            img {
+              width: 300px;
+              height: 300px;
+            }
+            &--text {
+              line-height: 300px;
+            }
+          }
+        }
+      }
+      .form-foot {
+        .send {
+          height: 30px;
+          width: 100%;
+          background: #008800;
+          color: #ffffff;
+          font-size: 18px;
+        }
+      }
+    }
+  }
+  .new-book {
+
   }
 }

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -3,22 +3,48 @@
 @section('title', 'CreateForm')
 
 @section('stylesheet')
+  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="/js/update_book.js" type="text/javascript" charset="UTF-8"></script>
   <link href="/css/sidebar.css" rel="stylesheet" type="text/css">
-  <link href="/css/book-form.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 
 @section('content')
-  <div class="book-form-area">
+  <div class="index-content">
     <!-- サイドバー(コンポーネント) -->
     @component('components.sidebar')
     @endcomponent
-    <form action="/book" method="post" class="book-form" enctype="multipart/form-data">
-      {{ csrf_field() }}
-      <table>
-      <tr><th>タイトル</th><td><input type="text" name="title" value="{{old('title')}}"></td></tr>
-      <tr><th>写真</th><td><input type="file" name="picture" value="{{old('picture')}}"></td></tr>
-      <tr><th></th><td><input type="submit" value="send"></td></tr>
-      </table>
-    </form>
+    <div class="books-list">
+      <div class="books-list__title">
+        新規登録
+      </div>
+      <div class="book-new">
+        <form action="/book" method="post" enctype="multipart/form-data">
+          {{ csrf_field() }}
+          <div class="form-contents">
+            <div class="form-left">
+              <div>
+                <div class="form-label">写真</div>
+                <div><input type="file" name="picture"></div>
+                <div class="form-input__picture afterimage"><span class="form-input__picture--text">写真が選択されていません</span></div>
+              </div>
+            </div>
+            <div class="form-right">
+              <div class="form-input">
+                <div class="form-label">タイトル名</div>
+                <div><input class="form-input__title" type="text" name="title" value="{{old('title')}}"></div>
+              </div>
+              <div class="form-input">
+                <div class="form-label">詳細</div>
+                <div><textarea class="form-input__detail" type="text" name="title" value="{{old('title')}}"></textarea></div>
+              </div>
+            </div>
+          </div>
+          <div class="form-foot">
+            <input class="send" type="submit" value="登録">
+          </div>
+        </form>
+      </div>
+    </div>
   </div>
 @endsection


### PR DESCRIPTION
# WHAT
新規登録ページのスタイルを修正する

# WHY
新規登録ページにて画像アップロードイメージをJSによって表示するように変更
コレに伴い、JS読み込み設定を追加

タイトル及び詳細情報を追加するフィールドを修正
詳細情報についてはテーブル設定がまだなので、別ブランチにて実装予定

<img width="1419" alt="スクリーンショット 2019-04-01 15 01 39" src="https://user-images.githubusercontent.com/45278393/55306404-1de34180-548f-11e9-89e6-f9c69e48399e.png">
