### PR TITLE
編集ページデザインを変更

### DIFF
--- a/database/migrations/2019_03_19_045831_create_bookdata_table.php
+++ b/database/migrations/2019_03_19_045831_create_bookdata_table.php
@@ -17,7 +17,7 @@ class CreateBookdataTable extends Migration
             $table->increments('id');
             $table->string('title');
             $table->string('picture')->nullable();
-            $table->text('detail');
+            $table->text('detail')->nullable();
             $table->timestamps();
         });
     }

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -148,6 +148,9 @@
 .index-content .books-list .book-new .form-contents .form-input__picture--text {
   line-height: 300px;
 }
+.index-content .books-list .book-new .form-contents .form-input [type="text"] {
+  margin-top: 10px;
+}
 .index-content .books-list .book-new .form-foot .send {
   height: 30px;
   width: 100%;

--- a/public/css/label.css
+++ b/public/css/label.css
@@ -1,0 +1,6 @@
+.label__important {
+  background: red;
+  color: white;
+  border-radius: 5px;
+  padding: 5px;
+}

--- a/public/js/update_book.js
+++ b/public/js/update_book.js
@@ -13,7 +13,7 @@ $(function() {
   // 画像削除
   $(".delete-picture").click(function() {
     $('.delete-picture').after("<input type='hidden' id='no-picture' name='picture' value='no-picture'>");
-    $('.afterimage').html("No Image");
+    $('.afterimage').html('<span class="form-input__picture--text">写真が削除されます</span>');
   });
   // 画像追加処理
   // アップロードするファイルを選択

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -148,6 +148,9 @@
               line-height: 300px;
             }
           }
+          [type="text"] {
+            margin-top: 10px;
+          }
         }
       }
       .form-foot {

--- a/public/scss/label.scss
+++ b/public/scss/label.scss
@@ -1,0 +1,8 @@
+.label {
+  &__important {
+    background: red;
+    color: white;
+    border-radius: 5px;
+    padding: 5px;
+  }
+}

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -36,7 +36,7 @@
               </div>
               <div class="form-input">
                 <div class="form-label">詳細</div>
-                <div><textarea class="form-input__detail" type="text" name="detail" value="{{old('title')}}"></textarea></div>
+                <div><textarea class="form-input__detail" type="text" name="detail">{{old('title')}}</textarea></div>
               </div>
             </div>
           </div>

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -6,67 +6,55 @@
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="/js/update_book.js" type="text/javascript" charset="UTF-8"></script>
   <link href="/css/sidebar.css" rel="stylesheet" type="text/css">
-  <link href="/css/book-form.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+  <link href="/css/label.css" rel="stylesheet" type="text/css">
 @endsection
 
 @section('content')
-  <div class="book-form-area">
+  <div class="index-content">
     <!-- サイドバー(コンポーネント) -->
     @component('components.sidebar')
     @endcomponent
-    <div>
-      <form action="/book/{{$form->id}}" method="post" class="book-form" enctype="multipart/form-data">
-        {{ csrf_field() }}
-        <table>
-        <input type="hidden" name="_method" value="PUT">
-        <tr><th>タイトル</th><td><input type="text" name="title" value="{{$form->title}}" class="book-title"></td></tr>
-        <tr><th>写真</th><td><input type="file" name="picture" value="{{$form->picture}}"></td></tr>
-        <tr><th>写真削除</th><td><input type="button" name="delete" value="削除" class="delete-picture"></td></tr>
-        <tr><th></th><td><input type="submit" value="send"></td></tr>
-        </table>
-      </form>
-      <div class="index-content">
-      <!-- <div> -->
-        <div class="books-list">
-          <div class="books-list__title">
-            編集のイメージ
-          </div>
-          <div class="book-table">
-            <table class="book-table__list">
-              <tr>
-                <th></th>
-                <th>写真</th>
-                <th>タイトル</th>
-                <th>登録日</th>
-              </tr>
-              <tr>
-                <td>編集後</td>
-                <td class="afterimage">
+    <div class="books-list">
+      <div class="books-list__title">
+        編集
+      </div>
+      <div class="book-new">
+        <form action="/book/{{$form->id}}" method="post" enctype="multipart/form-data">
+          {{ csrf_field() }}
+          <input type="hidden" name="_method" value="PUT">
+          <div class="form-contents">
+            <div class="form-left">
+              <div>
+                <div class="form-label">写真</div>
+                <div>
+                  <input type="file" name="picture" value="{{$form->picture}}">
+                  <input type="button" name="delete" value="削除" class="delete-picture">
+                </div>
+                <div class="form-input__picture afterimage">
                   @if (isset($form->picture))
                     <img src="{{$form->picture}}" width="100px">
                   @else
-                    No Image
+                    <span class="form-input__picture--text">写真が選択されていません</span>
                   @endif
-                </td>
-                <td class="aftertitle">{{$form->title}}</td>
-                <td>{{$form->created_at->format('y/m/d')}}</td>
-              </tr>
-              <tr>
-                <td>編集前</td>
-                <td>
-                  @if (isset($form->picture))
-                    <img src="{{$form->picture}}" width="100px">
-                  @else
-                    No Image
-                  @endif
-                </td>
-                <td><a href="/book/{{$form->id}}">{{$form->title}}</a></td>
-                <td>{{$form->created_at->format('y/m/d')}}</td>
-              </tr>
-            </table>
+                </div>
+              </div>
+            </div>
+            <div class="form-right">
+              <div class="form-input">
+                <lavel class="form-label">タイトル名</lavel><span class="label__important">必須</span>
+                <input class="form-input__title" type="text" name="title" value="{{$form->title}}">
+              </div>
+              <div class="form-input">
+                <lavel class="form-label">詳細</lavel>
+                <textarea class="form-input__detail" type="text" name="detail">{{$form->detail}}</textarea>
+              </div>
+            </div>
           </div>
-        </div>
+          <div class="form-foot">
+            <input class="send" type="submit" value="登録">
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -52,7 +52,7 @@
             </div>
           </div>
           <div class="form-foot">
-            <input class="send" type="submit" value="登録">
+            <input class="send" type="submit" value="更新">
           </div>
         </form>
       </div>


### PR DESCRIPTION
# WHAT
暫定デザインを廃止し、新規作成ページをベースとして
編集ページを作成する
## マイグレファイル、detailのnull許可を追加
database/migrations/2019_03_19_045831_create_bookdata_table.php
## スタイル設定変更
public/css/book-index.css
public/css/label.css
public/scss/book-index.scss
public/scss/label.scss
## JS、削除情報出力を変更
public/js/update_book.js
## ビューファイル表示形式変更
resources/views/book/create.blade.php
resources/views/book/edit.blade.php

# WHY
新規作成ページをベースに編集ページをリデザイン
画像削除消去時は削除実施の旨表示をする。
新規作成で追加したdetailに対応、また任意登録とする為にnull許可に変更。
textareaの既存テキスト表示の表記が誤っていた為、createビューと共に変更を実施
<img width="1421" alt="スクリーンショット 2019-04-01 17 04 03" src="https://user-images.githubusercontent.com/45278393/55312337-3a3baa00-54a0-11e9-8c43-e338bcb5f00c.png">

