### PR TITLE
メニューリスト再構成

### DIFF
--- a/public/css/menulist.css
+++ b/public/css/menulist.css
@@ -1,0 +1,14 @@
+.menulist__menutab {
+  margin-bottom: 10px;
+  padding: 0 30px 0;
+  height: 37px;
+  border-bottom: 1px solid #000;
+  display: flex;
+}
+.menulist__menutab .tab {
+  width: 133px;
+  height: 18px;
+  margin: 3px 8px 0 0;
+  padding: 9px 12px 5px 8px;
+  border-radius: 8px 8px 0 0;
+}

--- a/public/scss/menulist.scss
+++ b/public/scss/menulist.scss
@@ -1,0 +1,16 @@
+.menulist {
+  &__menutab {
+    margin-bottom: 10px;
+    padding: 0 30px 0;
+    height: 37px;
+    border-bottom: 1px solid #000;
+    display: flex;
+    .tab {
+      width: 133px;
+      height: 18px;
+      margin: 3px 8px 0 0;
+      padding: 9px 12px 5px 8px;
+      border-radius: 8px 8px 0 0;
+    }
+  }
+}

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -5,6 +5,7 @@
 @section('stylesheet')
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="/js/update_book.js" type="text/javascript" charset="UTF-8"></script>
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/book/create.blade.php
+++ b/resources/views/book/create.blade.php
@@ -14,10 +14,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -5,6 +5,7 @@
 @section('stylesheet')
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="/js/update_book.js" type="text/javascript" charset="UTF-8"></script>
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/book/edit.blade.php
+++ b/resources/views/book/edit.blade.php
@@ -14,10 +14,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/find.blade.php
+++ b/resources/views/book/find.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'FindPage')
 
 @section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/book/find.blade.php
+++ b/resources/views/book/find.blade.php
@@ -12,10 +12,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'TopPage')
 
 @section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -12,10 +12,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/isbn.blade.php
+++ b/resources/views/book/isbn.blade.php
@@ -12,10 +12,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/isbn.blade.php
+++ b/resources/views/book/isbn.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'ISBN')
 
 @section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/book/show.blade.php
+++ b/resources/views/book/show.blade.php
@@ -12,10 +12,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_book')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title bookpage-color">

--- a/resources/views/book/show.blade.php
+++ b/resources/views/book/show.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'ShowPage')
 
 @section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 

--- a/resources/views/components/menu_book.blade.php
+++ b/resources/views/components/menu_book.blade.php
@@ -1,4 +1,4 @@
-<div class="book-header__menutab">
+<div class="menulist__menutab">
   <a href="/book">
     <div class="tab bookpage-color">
       書籍トップ

--- a/resources/views/components/menu_grand.php
+++ b/resources/views/components/menu_grand.php
@@ -1,4 +1,4 @@
-<div class="book-header__menutab">
+<div class="menulist__menutab">
   <a href="/book">
     <div class="tab bookpage-color">
       登録書籍

--- a/resources/views/components/menu_mypage.blade.php
+++ b/resources/views/components/menu_mypage.blade.php
@@ -1,4 +1,4 @@
-<div class="book-header__menutab">
+<div class="menulist__menutab">
   <a href="/user">
     <div class="tab mypage-color">
       マイページトップ

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -32,11 +32,16 @@
       </div>
       <!-- パンくずは各ページにて個別処理 -->
       @yield('breadcrumbs')
+    </header>
 
+    <!-- メニュー -->
+    <div class="menulist">
       <!-- サイト内全体メニュー（コンポーネント） -->
       @component('components.menu_grand')
       @endcomponent
-    </header>
+      <!-- 各ページメニュー -->
+      @yield('pagemenu')
+    </div>
 
     <!-- 各ページ内容表示 -->
     @yield('content')

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -12,10 +12,11 @@
   </div>
 @endsection
 
+@section('pagemenu')
+  @include('components.menu_mypage')
+@endsection
+
 @section('content')
-  <!-- サブメニュー(コンポーネント) -->
-  @component('components.menu_mypage')
-  @endcomponent
   <div class="index-content">
     <div class="books-list">
       <div class="books-list__title mypage-color">

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'MyPage')
 
 @section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
   <link href="/css/book-index.css" rel="stylesheet" type="text/css">
 @endsection
 


### PR DESCRIPTION
# WHAT
メニューリストのコード記述について見直しを行い、再設定する。
## スタイルシート変更
public/css/menulist.css
public/scss/menulist.scss
## ビュー、メニュー設定修正
resources/views/book/create.blade.php
resources/views/book/edit.blade.php
resources/views/book/find.blade.php
resources/views/book/index.blade.php
resources/views/book/isbn.blade.php
resources/views/book/show.blade.php
resources/views/components/menu_book.blade.php
resources/views/components/menu_grand.php
resources/views/components/menu_mypage.blade.php
resources/views/layouts/layout.blade.php
resources/views/user/index.blade.php

# WHY
レイアウトにページ全体メニュー・コンテンツメニューがコンテンツ内にあり、メニューの配置として統一されていなかた為、menulistクラスを新設し、メニュー設定箇所を統一。
レイアウト・コンポーネント・ビューにてメニューの配置を再構成し、専用クラス名を設定した。
また、これにあわせメニューリスト専用のスタイルシートファイルを準備し必要な情報の載せ替えを実施した。
