### PR TITLE
ユーザー所有本の登録

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -28,7 +28,7 @@ class UserController extends Controller
      */
     public function create()
     {
-        //
+        return view('user.create');
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use App\Bookdata;
+use App\Property;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
@@ -18,7 +20,7 @@ class UserController extends Controller
     {
         $user = Auth::user();
         $property = User::userBook();
-        return view('user.index',['user'=>$user,'books'=>$property]);
+        return view('user.index',['user'=>$user, 'books'=>$property]);
     }
 
     /**
@@ -28,8 +30,9 @@ class UserController extends Controller
      */
     public function create()
     {
+        $books = Bookdata::all();
         $msg = '登録書籍を選択して下さい。';
-        return view('user.create',['msg'=>$msg]);
+        return view('user.create',['books'=>$books, 'msg'=>$msg]);
     }
 
     /**
@@ -40,7 +43,22 @@ class UserController extends Controller
      */
     public function store(Request $request)
     {
-        //
+      // 新規レコード生成
+      $property = new Property;
+      // リクエストデータ受取
+      $form = $request->all();
+      // フォームトークン削除
+      unset($form['_token']);
+      // ユーザー情報追加
+      $user = Auth::user()->id;
+      $form = $form + array('user_id' => $user);
+      // DB保存
+      $property->fill($form)->save();
+      // 登録完了メッセージ
+      $msg = "本を登録しました。";
+      // 次の登録用フォームデータ取得
+      $books = Bookdata::all();
+      return view('user.create',['books'=>$books, 'property'=>$property, 'msg'=>$msg]);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -30,9 +30,10 @@ class UserController extends Controller
      */
     public function create()
     {
-        $books = Bookdata::all();
+        // 所有書籍を除外して取得
+        $notProperties = User::userNothaveBook();
         $msg = '登録書籍を選択して下さい。';
-        return view('user.create',['books'=>$books, 'msg'=>$msg]);
+        return view('user.create',['books'=>$notProperties, 'msg'=>$msg]);
     }
 
     /**
@@ -57,8 +58,9 @@ class UserController extends Controller
       // 登録完了メッセージ
       $msg = "所有書籍を登録しました。";
       // 次の登録用フォームデータ取得
-      $books = Bookdata::all();
-      return view('user.create',['books'=>$books, 'property'=>$property, 'msg'=>$msg]);
+      // 所有書籍を除外して取得
+      $notProperties = User::userNothaveBook();
+      return view('user.create',['books'=>$notProperties, 'property'=>$property, 'msg'=>$msg]);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -28,7 +28,8 @@ class UserController extends Controller
      */
     public function create()
     {
-        return view('user.create');
+        $msg = '登録書籍を選択して下さい。';
+        return view('user.create',['msg'=>$msg]);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -55,7 +55,7 @@ class UserController extends Controller
       // DB保存
       $property->fill($form)->save();
       // 登録完了メッセージ
-      $msg = "本を登録しました。";
+      $msg = "所有書籍を登録しました。";
       // 次の登録用フォームデータ取得
       $books = Bookdata::all();
       return view('user.create',['books'=>$books, 'property'=>$property, 'msg'=>$msg]);

--- a/app/User.php
+++ b/app/User.php
@@ -48,4 +48,11 @@ class User extends Authenticatable
                         ->get();
         return $property;
     }
+    public function scopeUserNothaveBook()
+    {
+        $haveProperties = Property::where('user_id', [Auth::user()->id])->get('bookdata_id');
+        $notProperties = Bookdata::whereNotIn('id', $haveProperties)
+                        ->get();
+        return $notProperties;
+    }
 }

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -174,6 +174,13 @@
 .index-content .books-list .book-new .form-contents .form-input [type="text"] {
   margin-top: 10px;
 }
+.index-content .books-list .book-new .form-contents .form-input__select {
+  width: 60%;
+  height: 40px;
+  font-size: 20px;
+  border-radius: 15px;
+  padding: 3px 8px;
+}
 .index-content .books-list .book-new .form-foot .send {
   height: 30px;
   width: 50px;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -173,6 +173,13 @@
           [type="text"] {
             margin-top: 10px;
           }
+          &__select {
+            width: 60%;
+            height: 40px;
+            font-size: 20px;
+            border-radius: 15px;
+            padding: 3px 8px;
+          }
         }
       }
       .form-foot {

--- a/resources/views/components/menu_mypage.blade.php
+++ b/resources/views/components/menu_mypage.blade.php
@@ -7,10 +7,12 @@
   <div class="tab mypage-color">
     ユーザ情報編集
   </div>
+  <a href="/user/create">
+    <div class="tab mypage-color">
+      所有書籍登録
+    </div>
+  </a>
   <div class="tab mypage-color">
-    所有書籍登録
-  </div>
-  <div class="tab mypage-color">
-    所有書籍検索
+  所有書籍検索
   </div>
 </div>

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.layout')
+
+@section('title', 'CreateForm')
+
+@section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('user.create') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_mypage')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title mypage-color">
+        所有書籍登録
+      </div>
+      <div class="book-new">
+        <form action="/user/store" method="post" enctype="multipart/form-data">
+          {{ csrf_field() }}
+          <div class="form-contents">
+            <div class="form-one-size">
+              <div class="form-input">
+                <select class="form-input__select" name="have-book">
+                  <option value="test1">テスト1</option>
+                  <option value="test2">テスト2</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="form-foot">
+            <input class="send" type="submit" value="登録">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -23,6 +23,11 @@
       <div class="books-list__title mypage-color">
         所有書籍登録
       </div>
+      @if (isset($msg))
+        <div class="books-list__msg">
+            <span>{{$msg}}</span>
+        </div>
+      @endif
       <div class="book-new">
         <form action="/user/store" method="post" enctype="multipart/form-data">
           {{ csrf_field() }}

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -29,25 +29,28 @@
         </div>
       @endif
       <div class="book-new">
-        <form action="/user" method="post" enctype="multipart/form-data">
-          {{ csrf_field() }}
-          <div class="form-contents">
-            <div class="form-one-size">
-              <div class="form-input">
-                <select class="form-input__select" name="bookdata_id">
-                @if (isset($books))
-                  @foreach ($books as $book)
-                    <option value="{{$book->id}}">{{$book->title}}</option>
-                  @endforeach
-                @endif
-                </select>
+        @if (isset($books) && count($books) != 0)
+          <form action="/user" method="post" enctype="multipart/form-data">
+            {{ csrf_field() }}
+            <div class="form-contents">
+              <div class="form-one-size">
+                <div class="form-input">
+                  <select class="form-input__select" name="bookdata_id">
+                    @foreach ($books as $book)
+                      <option value="{{$book->id}}">{{$book->title}}</option>
+                    @endforeach
+                  </select>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="form-foot">
-            <input class="send" type="submit" value="登録">
-          </div>
-        </form>
+            <div class="form-foot">
+              <input class="send" type="submit" value="登録">
+            </div>
+          </form>
+        @else
+          <span>全ての書籍が登録済みです。</span>
+        @endif
+
       </div>
       @if (isset($property))
         @component('components.book_detail',['book' => $property->bookdata])

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -29,14 +29,17 @@
         </div>
       @endif
       <div class="book-new">
-        <form action="/user/store" method="post" enctype="multipart/form-data">
+        <form action="/user" method="post" enctype="multipart/form-data">
           {{ csrf_field() }}
           <div class="form-contents">
             <div class="form-one-size">
               <div class="form-input">
-                <select class="form-input__select" name="have-book">
-                  <option value="test1">テスト1</option>
-                  <option value="test2">テスト2</option>
+                <select class="form-input__select" name="bookdata_id">
+                @if (isset($books))
+                  @foreach ($books as $book)
+                    <option value="{{$book->id}}">{{$book->title}}</option>
+                  @endforeach
+                @endif
                 </select>
               </div>
             </div>
@@ -46,6 +49,9 @@
           </div>
         </form>
       </div>
+      @if (isset($property))
+        <div>{{$property->bookdata->title}}</div>
+      @endif
     </div>
   </div>
 @endsection

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -50,7 +50,8 @@
         </form>
       </div>
       @if (isset($property))
-        <div>{{$property->bookdata->title}}</div>
+        @component('components.book_detail',['book' => $property->bookdata])
+        @endcomponent
       @endif
     </div>
   </div>

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -46,3 +46,9 @@ Breadcrumbs::for('user.index', function ($trail) {
     $trail->parent('toppage');
     $trail->push('マイページ', url('user.index'));
 });
+
+// トップページ / マイページ / 所有書籍登録
+Breadcrumbs::for('user.create', function ($trail) {
+    $trail->parent('user.index');
+    $trail->push('所有書籍登録', url('user.create'));
+});


### PR DESCRIPTION
# WHAT
本DBから選択したタイトルをユーザーが所有している本として登録する
## コントローラ、書籍登録処理追加
app/Http/Controllers/UserController.php
## モデル、未所持書籍情報取得スコープ追加
app/User.php
## スタイルシート設定追加
public/css/book-index.css
public/scss/book-index.scss
## パンくずリスト、設定追加
resources/views/components/menu_mypage.blade.php
routes/breadcrumbs.php
## 書籍登録ビュー新規追加
resources/views/user/create.blade.php

# WHY
ユーザー所有書籍を登録する処理を追加。
フォームより登録する書籍idを取得、ログイン中ユーザーidと共にPropertiesテーブルに保存することで、所有書籍情報を追加する。
登録フォームのデータは、予め全bookdataから登録済みの書籍を除いて表示する形とした、これにより重複登録を回避した。
未所持書籍情報取得にはスコープを作成してDBよりデータ取得をしている。
フォームにセレクトタグを使用するにあたりスタイルシートに設定を追加している。
