### PR TITLE
ユーザー所有本詳細表示設定

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -19,7 +19,7 @@ class UserController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $property = User::userBook();
+        $property = User::userGetBook();
         return view('user.index',['user'=>$user, 'books'=>$property]);
     }
 
@@ -71,8 +71,8 @@ class UserController extends Controller
      */
     public function show($id)
     {
-        $book = Bookdata::find($id);
-        return view('user.show', ['book' => $book]);
+        $property = Property::find($id);
+        return view('user.show', ['property' => $property]);
       }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -120,6 +120,7 @@ class UserController extends Controller
       $properties = Property::where('user_id', Auth::user()->id)
                         ->join('bookdata','bookdata.id','=','properties.bookdata_id')
                         ->where('title', 'like', "%{$title}%")
+                        ->select('properties.id','title','picture','cover')
                         ->get();
       $param = ['input' => $title, 'books' => $properties];
       return view('user.find', $param);

--- a/app/User.php
+++ b/app/User.php
@@ -41,10 +41,11 @@ class User extends Authenticatable
     {
         return $this->hasMany('App\Property');
     }
-    public function scopeUserBook()
+    public function scopeUserGetBook()
     {
         $property = Property::where('user_id', Auth::user()->id)
                         ->join('bookdata','bookdata.id','=','properties.bookdata_id')
+                        ->select('properties.id','title','picture','cover')
                         ->get();
         return $property;
     }

--- a/database/migrations/2019_04_08_220852_create_properties_table.php
+++ b/database/migrations/2019_04_08_220852_create_properties_table.php
@@ -17,6 +17,9 @@ class CreatePropertiesTable extends Migration
             $table->bigIncrements('id');
             $table->integer('user_id');
             $table->integer('bookdata_id');
+            $table->integer('number')->nullable();
+            $table->date('getdate')->nullable();
+            $table->text('freememo')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -23,8 +23,13 @@
       <div class="books-list__title bookpage-color">
         登録書籍一覧
       </div>
-      @include('components.books_list')
+      @if (isset($books))
+        @component('components.books_list',['books'=>$books])
+          @slot('page_path')
+            book
+          @endslot
+        @endcomponent
+      @endif
     </div>
-
   </div>
 @endsection

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -3,7 +3,7 @@
     @foreach ($books as $book)
       <div class="book-table__list">
         <div class="book-table__list--picture">
-          <a href="/{{Request::path()}}/{{$book->id}}">
+          <a href="/{{$page_path}}/{{$book->id}}">
             @if (isset($book->picture))
               <img src="{{$book->picture}}">
             @elseif (isset($book->cover))

--- a/resources/views/user/find.blade.php
+++ b/resources/views/user/find.blade.php
@@ -31,7 +31,13 @@
             <input type="submit" class="book-find__input--submit" value="検索">
           </div>
         </form>
-        @include('components.books_list')
+        @if (isset($books))
+          @component('components.books_list',['books'=>$books])
+            @slot('page_path')
+              user
+            @endslot
+          @endcomponent
+        @endif
     </div>
   </div>
 @endsection

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -23,8 +23,13 @@
       <div class="books-list__title mypage-color">
         所有書籍一覧
       </div>
-      @include('components.books_list')
+      @if (isset($books))
+        @component('components.books_list',['books'=>$books])
+          @slot('page_path')
+            user
+          @endslot
+        @endcomponent
+      @endif
     </div>
-
   </div>
 @endsection

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('user.show',$book) }}
+    {{ Breadcrumbs::render('user.show',$property) }}
   </div>
 @endsection
 
@@ -23,15 +23,49 @@
       <div class="books-list__title mypage-color">
         所有書籍詳細
         <div class="books-list__title--navigation">
-          <a href="/user/{{$book->id}}/edit" class="nav-btn edit">編集</a>
-          <form action="/user/{{$book->id}}" method="post">
+          <a href="/user/{{$property->id}}/edit" class="nav-btn edit">編集</a>
+          <form action="/user/{{$property->id}}" method="post">
             {{ csrf_field() }}
             <input type="hidden" name="_method" value="DELETE">
             <input type="submit" class="nav-btn delete" value="削除">
           </form>
         </div>
       </div>
-      @include('components.book_detail')
+
+      <!-- ユーザー所有書籍詳細情報 -->
+      <div class="book-detail">
+        <div class="book-detail__picture">
+          @if (isset($property->bookdata->picture))
+            <img src="{{$property->bookdata->picture}}">
+          @elseif (isset($property->bookdata->cover))
+            <img src="{{$property->bookdata->cover}}">
+          @else
+            <img src="../image/no-entry.jpg">
+            <br>写真は登録されていません。
+          @endif
+        </div>
+        <div class="book-detail__document">
+          <h3 class="document-index">所持書籍情報</h3>
+          <div class="document-content">
+            <div class="document-content__label">タイトル</div>
+            <div class="document-content__column">{{$property->bookdata->title}}</div>
+          </div>
+          <div class="document-content">
+            <div class="document-content__label">所持数</div>
+            <div class="document-content__column">{{$property->number}}</div>
+          </div>
+          <div class="document-content">
+            <div class="document-content__label">取得日</div>
+            <div class="document-content__column">{{$property->getdate}}</div>
+          </div>
+          <div class="document-content">
+            <div class="document-content__label">フリーメモ</div>
+            <div class="document-content__column">{{$property->freememo}}</div>
+          </div>
+        </div>
+      </div>
+
+
     </div>
   </div>
 @endsection


### PR DESCRIPTION
# WHAT
ユーザー所有本の詳細情報をDB追加し表示させる
## コントローラ、詳細ページ情報取得データ変更
app/Http/Controllers/UserController.php
## モデル、スコープ名修正
app/User.php
## マイグレーションファイル、カラム追加
database/migrations/2019_04_08_220852_create_properties_table.php
## コンポーネントスロット設定
resources/views/book/index.blade.php
resources/views/components/books_list.blade.php
resources/views/user/find.blade.php
resources/views/user/index.blade.php
## ビューファイル、詳細表示情報設定
resources/views/user/show.blade.php

# WHY
詳細表示画面について本情報表示と同様の設定としていたが、
所有情報詳細表示は所有情報のidを必要とするため、表示内容を変更した。
これに伴い、ユーザー所有詳細情報となるカラムを新規に追加し、本詳細情報とは異なる内容とした。
また、各ページの検索結果より詳細ページへの遷移を可能としているが、表示パスに一部問題があったため、コンポーネント及びスロットを利用して対応するパス表示を設定することとした。
