### PR TITLE
ユーザー所有本情報登録ページ、カラム追加

### DIFF
--- a/database/migrations/2019_04_08_220852_create_properties_table.php
+++ b/database/migrations/2019_04_08_220852_create_properties_table.php
@@ -17,7 +17,7 @@ class CreatePropertiesTable extends Migration
             $table->bigIncrements('id');
             $table->integer('user_id');
             $table->integer('bookdata_id');
-            $table->integer('number')->nullable();
+            $table->integer('number');
             $table->date('getdate')->nullable();
             $table->text('freememo')->nullable();
             $table->timestamps();

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -175,7 +175,7 @@
   margin-top: 10px;
 }
 .index-content .books-list .book-new .form-contents .form-input__select {
-  width: 60%;
+  width: 100%;
   height: 40px;
   font-size: 20px;
   border-radius: 15px;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -174,7 +174,7 @@
             margin-top: 10px;
           }
           &__select {
-            width: 60%;
+            width: 100%;
             height: 40px;
             font-size: 20px;
             border-radius: 15px;

--- a/resources/views/components/book_property_detail.blade.php
+++ b/resources/views/components/book_property_detail.blade.php
@@ -1,0 +1,31 @@
+<div class="book-detail">
+  <div class="book-detail__picture">
+    @if (isset($property->bookdata->picture))
+      <img src="{{$property->bookdata->picture}}">
+    @elseif (isset($property->bookdata->cover))
+      <img src="{{$property->bookdata->cover}}">
+    @else
+      <img src="../image/no-entry.jpg">
+      <br>写真は登録されていません。
+    @endif
+  </div>
+  <div class="book-detail__document">
+    <h3 class="document-index">所持書籍情報</h3>
+    <div class="document-content">
+      <div class="document-content__label">タイトル</div>
+      <div class="document-content__column">{{$property->bookdata->title}}</div>
+    </div>
+    <div class="document-content">
+      <div class="document-content__label">所持数</div>
+      <div class="document-content__column">{{$property->number}}</div>
+    </div>
+    <div class="document-content">
+      <div class="document-content__label">取得日</div>
+      <div class="document-content__column">{{$property->getdate}}</div>
+    </div>
+    <div class="document-content">
+      <div class="document-content__label">フリーメモ</div>
+      <div class="document-content__column">{{$property->freememo}}</div>
+    </div>
+  </div>
+</div>

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -44,11 +44,11 @@
                 </div>
                 <div class="form-input">
                   <div class="form-label">所持数</div>
-                  <div><input class="form-input__number" type="number" name="number" value="1"></div>
+                  <div><input class="form-input__input" type="number" name="number" value="1"></div>
                 </div>
                 <div class="form-input">
                   <div class="form-label">所持日</div>
-                  <div><input class="form-input__date" type="date" name="getdate" value="{{old('getdate')}}"></div>
+                  <div><input class="form-input__input" type="date" name="getdate" value="{{old('getdate')}}"></div>
                 </div>
                 <div class="form-input">
                   <div class="form-label">フリーメモ</div>

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -35,11 +35,24 @@
             <div class="form-contents">
               <div class="form-one-size">
                 <div class="form-input">
+                  <div class="form-label">タイトル名</div>
                   <select class="form-input__select" name="bookdata_id">
                     @foreach ($books as $book)
                       <option value="{{$book->id}}">{{$book->title}}</option>
                     @endforeach
                   </select>
+                </div>
+                <div class="form-input">
+                  <div class="form-label">所持数</div>
+                  <div><input class="form-input__number" type="number" name="number" value="1"></div>
+                </div>
+                <div class="form-input">
+                  <div class="form-label">所持日</div>
+                  <div><input class="form-input__date" type="date" name="getdate" value="{{old('getdate')}}"></div>
+                </div>
+                <div class="form-input">
+                  <div class="form-label">フリーメモ</div>
+                  <div><textarea class="form-input__detail" type="text" name="freememo">{{old('freememo')}}</textarea></div>
                 </div>
               </div>
             </div>

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -63,11 +63,9 @@
         @else
           <span>全ての書籍が登録済みです。</span>
         @endif
-
       </div>
       @if (isset($property))
-        @component('components.book_detail',['book' => $property->bookdata])
-        @endcomponent
+        @include('components.book_property_detail')
       @endif
     </div>
   </div>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -33,39 +33,7 @@
       </div>
 
       <!-- ユーザー所有書籍詳細情報 -->
-      <div class="book-detail">
-        <div class="book-detail__picture">
-          @if (isset($property->bookdata->picture))
-            <img src="{{$property->bookdata->picture}}">
-          @elseif (isset($property->bookdata->cover))
-            <img src="{{$property->bookdata->cover}}">
-          @else
-            <img src="../image/no-entry.jpg">
-            <br>写真は登録されていません。
-          @endif
-        </div>
-        <div class="book-detail__document">
-          <h3 class="document-index">所持書籍情報</h3>
-          <div class="document-content">
-            <div class="document-content__label">タイトル</div>
-            <div class="document-content__column">{{$property->bookdata->title}}</div>
-          </div>
-          <div class="document-content">
-            <div class="document-content__label">所持数</div>
-            <div class="document-content__column">{{$property->number}}</div>
-          </div>
-          <div class="document-content">
-            <div class="document-content__label">取得日</div>
-            <div class="document-content__column">{{$property->getdate}}</div>
-          </div>
-          <div class="document-content">
-            <div class="document-content__label">フリーメモ</div>
-            <div class="document-content__column">{{$property->freememo}}</div>
-          </div>
-        </div>
-      </div>
-
-
+      @include('components.book_property_detail')
     </div>
   </div>
 @endsection


### PR DESCRIPTION
# WHAT
ユーザー所有本の登録時のカラムを追加する
## マイグレーションファイル、numberの必須化
database/migrations/2019_04_08_220852_create_properties_table.php
## スタイルシート修正
public/css/book-index.css
public/scss/book-index.scss
## ユーザー所有本情報のコンポーネント化
resources/views/components/book_property_detail.blade.php
## createビュー、追加カラム登録用フォームを設定
resources/views/user/create.blade.php
## showビュー、コンポーネント指定
resources/views/user/show.blade.php

# WHY
ユーザー所有本記録DBにカラムを追加したので、それに対応するcreateビューからの情報情報登録機能を追加。
show及びcreateビューで同じ表示を扱う為に新たにコンポーネント化を実施した。
ユーザー所有数を必須化とし、DBカラム設定を変更した。
