### PR TITLE
パスワードリセット機能

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,7 +25,7 @@ class ResetPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/login';
 
     /**
      * Create a new controller instance.

--- a/app/Notifications/CustomResetPassword.php
+++ b/app/Notifications/CustomResetPassword.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomResetPassword extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    // public function __construct()
+    // {
+    //     //
+    // }
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    // ->line('The introduction to the notification.')
+                    // ->action('Notification Action', url('/'))
+                    // ->line('Thank you for using our application!');
+                    // ->from('admin@example.com', config('app.name'))
+                    ->subject('パスワード再設定')
+                    ->line('下のボタンをクリックしてパスワードを再設定してください。')
+                    ->action('パスワード再設定', url(config('app.url').route('password.reset', $this->token, false)))
+                    ->line('もし心当たりがない場合は、本メッセージは破棄してください。');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
+use App\Notifications\CustomResetPassword;
 
 class User extends Authenticatable
 {
@@ -40,5 +41,9 @@ class User extends Authenticatable
     public function properties()
     {
         return $this->hasMany('App\Property');
+    }
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new CustomResetPassword($token));
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -53,7 +53,7 @@ return [
     |
     */
 
-    'url' => env('APP_URL', 'http://localhost'),
+    'url' => env('APP_URL', 'https://protected-fortress-61913.herokuapp.com/'),
 
     'asset_url' => env('ASSET_URL', null),
 
@@ -95,7 +95,7 @@ return [
     |
     */
 
-    'fallback_locale' => 'en',
+    'fallback_locale' => 'ja',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mail.php
+++ b/config/mail.php
@@ -56,8 +56,8 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'address' => env('MAIL_FROM_ADDRESS', null),
+        'name' => env('MAIL_FROM_NAME', null),
     ],
 
     /*

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -56,3 +56,7 @@ a {
   font-size: 20px;
   padding: 10px;
 }
+.auth-contents__form .form-group__pass {
+  font-size: 10px;
+  margin-left: 20px;
+}

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -60,3 +60,6 @@ a {
   font-size: 10px;
   margin-left: 20px;
 }
+.auth-contents__form .form-group__pass--color {
+  color: red;
+}

--- a/public/scss/auth.scss
+++ b/public/scss/auth.scss
@@ -63,6 +63,9 @@ a {
       &__pass {
         font-size: 10px;
         margin-left: 20px;
+        &--color {
+          color: red;
+        }
       }
     }
   }

--- a/public/scss/auth.scss
+++ b/public/scss/auth.scss
@@ -60,6 +60,10 @@ a {
         font-size: 20px;
         padding: 10px;
       }
+      &__pass {
+        font-size: 10px;
+        margin-left: 20px;
+      }
     }
   }
 }

--- a/public/scss/top-page.scss
+++ b/public/scss/top-page.scss
@@ -6,10 +6,6 @@ a {
   text-decoration: none;
 }
 
-div {
-  // border: 1px solid black;
-}
-
 .toppage-contents {
   &__top {
     height: 200px;

--- a/resources/lang/ja/auth.php
+++ b/resources/lang/ja/auth.php
@@ -12,8 +12,8 @@ return [
     | these language lines according to your application's requirements.
     |
     */
-
-    'failed' => 'These credentials do not match our records.',
-    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+    
+    'failed' => '認証情報が記録と一致しません。',
+    'throttle' => 'ログイン試行が規定回数を超えました。:seconds秒後に再開できます。',
 
 ];

--- a/resources/lang/ja/pagination.php
+++ b/resources/lang/ja/pagination.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'previous' => '&laquo; Previous',
-    'next' => 'Next &raquo;',
+    'previous' => '&laquo; 前へ',
+    'next' => '次へ &raquo;',
 
 ];

--- a/resources/lang/ja/passwords.php
+++ b/resources/lang/ja/passwords.php
@@ -13,10 +13,10 @@ return [
     |
     */
 
-    'password' => 'Passwords must be at least eight characters and match the confirmation.',
-    'reset' => 'Your password has been reset!',
-    'sent' => 'We have e-mailed your password reset link!',
-    'token' => 'This password reset token is invalid.',
-    'user' => "We can't find a user with that e-mail address.",
+    'password' => 'パスワードは6文字以上にして、確認用入力欄と一致させてください。',
+    'reset' => 'パスワードは再設定されました！',
+    'sent' => 'パスワード再設定用のURLをメールで送りました。',
+    'token' => 'パスワード再設定用のトークンが不正です。',
+    'user' => "メールアドレスに一致するユーザーが存在しません。",
 
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -20,7 +20,7 @@
         <input class="form-group__input" type="text" name="email" value="{{ old('email') }}">
       </div>
       <div class="form-group">
-        <div class="form-group__lavel"><lavel>パスワード</lavel><span class="form-group__pass"><a href="{{ route('password.request') }}">パスワードを忘れた場合</a></span></div>
+        <div class="form-group__lavel"><lavel>パスワード</lavel><span class="form-group__pass"><a class="form-group__pass--color" href="{{ route('password.request') }}">パスワードを忘れた場合</a></span></div>
         <input class="form-group__input" type="password" name="password">
       </div>
       <div class="form-group">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -20,7 +20,7 @@
         <input class="form-group__input" type="text" name="email" value="{{ old('email') }}">
       </div>
       <div class="form-group">
-        <div class="form-group__lavel"><lavel>パスワード</lavel></div>
+        <div class="form-group__lavel"><lavel>パスワード</lavel><span class="form-group__pass"><a href="{{ route('password.request') }}">パスワードを忘れた場合</a></span></div>
         <input class="form-group__input" type="password" name="password">
       </div>
       <div class="form-group">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,36 @@
 @extends('layouts.app')
 
+@section('title', 'パスワードリセット')
+
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+<div class="auth-contents">
+  <div class="auth-contents__message">
 
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+  @if (session('status'))
+    <div class="alert alert-success" role="alert">
+      {{ session('status') }}
     </div>
+  @else
+    <p class="auth-contents__message--message">パスワード変更します、登録したメールアドレスを入力してください。</p>
+    <p class="auth-contents__message--message">※確認の為のメールを送信します。</p>
+    @if ($errors->has('email'))
+      <span class="auth-contents__message--message" role="alert">
+        <strong>{{ $errors->first('email') }}</strong>
+      </span>
+    @endif
+  @endif
+  </div>
+  <div class="auth-contents__form">
+    <form action="{{ route('password.email') }}" method="post">
+      {{ csrf_field() }}
+      <div class="form-group">
+        <div class="form-group__lavel"><lavel>メールアドレス</lavel></div>
+        <input class="form-group__input" type="text" name="email" value="{{ old('email') }}">
+      </div>
+      <div class="form-group">
+        <input class="form-group__submit" type="submit" value="送信">
+      </div>
+    </form>
+  </div>
 </div>
 @endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,65 +1,43 @@
 @extends('layouts.app')
 
+@section('title', 'パスワード再設定')
+
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+<div class="auth-contents">
+  <div class="auth-contents__message">
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}">
-                        @csrf
-
-                        <input type="hidden" name="token" value="{{ $token }}">
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Reset Password') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+  @if (session('status'))
+    <div class="alert alert-success" role="alert">
+      {{ session('status') }}
     </div>
+  @else
+    <p class="auth-contents__message--message">新しいパスワードを設定します。</p>
+    @foreach ($errors->all() as $error)
+      <p class="auth-contents__message--error">{{ $error }}</p>
+    @endforeach
+
+  @endif
+  </div>
+  <div class="auth-contents__form">
+    <form action="{{ route('password.update') }}" method="post">
+      {{ csrf_field() }}
+      <input type="hidden" name="token" value="{{ $token }}">
+      <div class="form-group">
+        <div class="form-group__lavel"><lavel>メールアドレス</lavel></div>
+        <input class="form-group__input" type="text" name="email" value="{{ old('email') }}">
+      </div>
+      <div class="form-group">
+        <div class="form-group__lavel"><lavel>パスワード</lavel></div>
+        <input class="form-group__input" type="password" name="password">
+      </div>
+      <div class="form-group">
+        <div class="form-group__lavel"><lavel>パスワード（確認）</lavel></div>
+        <input class="form-group__input" type="password" name="password_confirmation">
+      </div>
+      <div class="form-group">
+        <input class="form-group__submit" type="submit" value="送信">
+      </div>
+    </form>
+  </div>
 </div>
 @endsection

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -1,0 +1,62 @@
+@component('mail::message')
+{{-- Greeting --}}
+@if (! empty($greeting))
+# {{ $greeting }}
+@else
+@if ($level === 'error')
+# @lang('Whoops!')
+@else
+# @lang('Hello!')
+@endif
+@endif
+
+{{-- Intro Lines --}}
+@foreach ($introLines as $line)
+{{ $line }}
+
+@endforeach
+
+{{-- Action Button --}}
+@isset($actionText)
+<?php
+    switch ($level) {
+        case 'success':
+        case 'error':
+            $color = $level;
+            break;
+        default:
+            $color = 'primary';
+    }
+?>
+@component('mail::button', ['url' => $actionUrl, 'color' => $color])
+{{ $actionText }}
+@endcomponent
+@endisset
+
+{{-- Outro Lines --}}
+@foreach ($outroLines as $line)
+{{ $line }}
+
+@endforeach
+
+{{-- Salutation --}}
+@if (! empty($salutation))
+{{ $salutation }}
+@else
+@lang('Regards'),<br>{{ config('app.name') }}
+@endif
+
+{{-- Subcopy --}}
+@isset($actionText)
+@slot('subcopy')
+@lang(
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
+    'into your web browser: [:actionURL](:actionURL)',
+    [
+        'actionText' => $actionText,
+        'actionURL' => $actionUrl,
+    ]
+)
+@endslot
+@endisset
+@endcomponent

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -6,7 +6,7 @@
 @if ($level === 'error')
 # @lang('Whoops!')
 @else
-# @lang('Hello!')
+こんにちは。
 @endif
 @endif
 
@@ -43,20 +43,14 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>{{ config('app.name') }}
+{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}
 @isset($actionText)
 @slot('subcopy')
-@lang(
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
-    [
-        'actionText' => $actionText,
-        'actionURL' => $actionUrl,
-    ]
-)
+{{ $actionText }}ボタンが利用できない場合は、以下のURLをコピー＆ペーストしてブラウザから直接アクセスしてください。
+[{{ $actionUrl }}]({!! $actionUrl !!})
 @endslot
 @endisset
 @endcomponent


### PR DESCRIPTION
# WHAT
パスワードリセット機能を実装
Auth機能を拡充し、パスワードを忘れた時に再設定できるようにする。
## 設定
### パスワード設定後、リダイレクト先設定
app/Http/Controllers/Auth/ResetPasswordController.php
### アプリケーション設定、url設定修正
config/app.php
config/mail.php
### 送信メール設定
app/Notifications/CustomResetPassword.php
resources/views/vendor/notifications/email.blade.php
### モデル、カスタムメール設定適用
app/User.php
### 言語ファイル、日本語化設定変更
resources/lang/ja/auth.php
resources/lang/ja/pagination.php
resources/lang/ja/passwords.php
## ビューファイル
### ログインビュー、リセットページリンク設定
resources/views/auth/login.blade.php
### リセットビュー修正
resources/views/auth/passwords/email.blade.php
resources/views/auth/passwords/reset.blade.php
### スタイル設定
public/css/auth.css
public/scss/auth.scss

# WHY
## フォームについて
Auth標準のパスワードリセットページは既に作成していたので、フォームをログインページをベースとして再作成した。
ログイン時にパスワードが分からなくなった事を想定し、ログインページからパスワードリセットするためのページへのリンクを準備。
メールアドレスが登録されている物ではないなど、エラー時はエラーメッセージを表示できるようにした。
エラーメッセージは英語になっていた為、日本語化ファイルを設定。
## 送信メールについて
メール内にパスワード変更を実施するURLが記載されるが、URL情報はアプリのURL設定を元に実施される為、アプリ設定URLを修正。
送信メールはデフォルトでは英語標記となるため、日本語化を実施。
本文をカスタムファイルで修正、テンプレート部分はテンプレートをオーバーライドする形で変更を実施。オーバーライドはUserモデルで設定を実施している。
## イメージ 4/4
### パスワードリセットページへのリンク 1/4
<img width="557" alt="スクリーンショット 2019-04-19 0 07 21" src="https://user-images.githubusercontent.com/45278393/56401464-eb5d8500-6293-11e9-990a-d7ebdca380ef.png">
### リセットアカウントメールアドレス確認 2/4
<img width="1247" alt="スクリーンショット 2019-04-19 0 07 28" src="https://user-images.githubusercontent.com/45278393/56401475-f87a7400-6293-11e9-9fd0-5c7c4fa3afb9.png">
### パスワード再設定 3/4
<img width="1137" alt="スクリーンショット 2019-04-19 0 12 07" src="https://user-images.githubusercontent.com/45278393/56401487-07612680-6294-11e9-83ae-fd9f90375f1c.png">
### 送信メール 4/4
<img width="1048" alt="スクリーンショット 2019-04-19 10 27 38" src="https://user-images.githubusercontent.com/45278393/56401494-0fb96180-6294-11e9-96da-395a2ea53918.png">
