### PR TITLE
新規登録時のメールアドレス確認

### DIFF
--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -25,7 +25,7 @@ class VerificationController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/book';
 
     /**
      * Create a new controller instance.

--- a/app/Notifications/CustomVerifyEmail.php
+++ b/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/CustomVerifyEmail.php
+++ b/app/Notifications/CustomVerifyEmail.php
@@ -6,8 +6,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Auth\Notifications\VerifyEmail;
 
-class CustomVerifyEmail extends Notification
+class CustomVerifyEmail extends VerifyEmail
 {
     use Queueable;
 
@@ -41,9 +42,10 @@ class CustomVerifyEmail extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-                    ->line('The introduction to the notification.')
-                    ->action('Notification Action', url('/'))
-                    ->line('Thank you for using our application!');
+            ->subject('メールアドレス確認')
+            ->line('下のボタンをクリックしてメールアドレスの確認を完了してください。')
+            ->action('パスワード確認', $this->verificationUrl($notifiable))
+            ->line('もし心当たりがない場合は、本メッセージは破棄してください。');
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -3,14 +3,15 @@
 namespace App;
 
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;
+use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use App\Notifications\CustomResetPassword;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmailContract
 {
-    use Notifiable;
+    use MustVerifyEmail, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/User.php
+++ b/app/User.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use App\Notifications\CustomResetPassword;
+use App\Notifications\CustomVerifyEmail;
 
 class User extends Authenticatable implements MustVerifyEmailContract
 {
@@ -46,5 +47,9 @@ class User extends Authenticatable implements MustVerifyEmailContract
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new CustomResetPassword($token));
+    }
+    public function sendEmailVerificationNotification()
+    {
+        $this->notify(new CustomVerifyEmail());
     }
 }

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,24 +1,18 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
-
-                <div class="card-body">
-                    @if (session('resent'))
-                        <div class="alert alert-success" role="alert">
-                            {{ __('A fresh verification link has been sent to your email address.') }}
-                        </div>
-                    @endif
-
-                    {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
-                </div>
-            </div>
-        </div>
+<div class="auth-contents">
+  <div class="auth-contents__message">
+    @if (session('resent'))
+    <div class="auth-contents__message--message" role="alert">メールを再送しました。</div>
+    @endif
+    <div class="auth-contents__message--message">新規登録を受け付けました。</div>
+    <div class="auth-contents__message--message">登録したメールアドレス宛にメールを送信しました、メールを確認して登録を完了させて下さい。</div>
+    <div class="auth-contents__message--message">
+      メールが送付されていない場合
+      <a href="{{ route('verification.resend') }}">こちらをクリック</a>
+      することで、再送できます。
     </div>
+  </div>
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ Route::get('/', function () {
 Auth::routes(['verify' => true]);
 
 // ログイン必須ページ
-Route::group(['middleware' => ['auth']], function () {
+Route::group(['middleware' => ['verified']], function () {
   Route::get('/book/isbn', 'BookController@getIsbn');
   Route::post('/book/isbn', 'BookController@postIsbn');
   Route::get('/book/find', 'BookController@find')->name('book.find');

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ Route::get('/', function () {
 });
 
 // ログインルート
-Auth::routes();
+Auth::routes(['verify' => true]);
 
 // ログイン必須ページ
 Route::group(['middleware' => ['auth']], function () {


### PR DESCRIPTION
# WHAT
新規登録時にメールを送信し、本人確認を行う
## verified設定、リダイレクト
app/Http/Controllers/Auth/VerificationController.php
## メール文章の日本語化設定
app/Notifications/CustomVerifyEmail.php
app/User.php
## ビュー、メール送付後のメッセージ表示
resources/views/auth/verify.blade.php
## ルーティング、認証確認必須化設定
routes/web.php

# WHY
新規登録時にメール送付し、確認を必須化した。
未確認状態ではログインできないように、ルーティングのミドルウェア設定を修正。
基本となるメール送付設定は、パスワードリセット設定時に実装済み。
## 表示イメージ 2/2
メール送付メッセージ 1/2
<img width="747" alt="スクリーンショット 2019-04-19 14 43 35" src="https://user-images.githubusercontent.com/45278393/56410267-73a15180-62b7-11e9-8a39-466ec248e25a.png">
送付メール 2/2
<img width="1039" alt="スクリーンショット 2019-04-19 15 17 40" src="https://user-images.githubusercontent.com/45278393/56410271-7603ab80-62b7-11e9-8f0c-8bfd2c5bc480.png">
