### PR TITLE
メールアドレス認証中ステータスでのユーザ切替

### DIFF
--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -16,5 +16,13 @@
       することで、再送できます。
     </div>
   </div>
+  <div class="auth-contents__form">
+    <form action="{{ route('logout') }}" method="post">
+      {{ csrf_field() }}
+      <div class="form-group">
+        <input class="form-group__submit" type="submit" value="別のユーザーに切り替える">
+      </div>
+    </form>
+  </div>
 </div>
 @endsection


### PR DESCRIPTION
# WHAT
新規登録時のメールアドレス認証中時にユーザーの切替ができるように対応する。
## ユーザー切り替えボタンの設置
resources/views/auth/verify.blade.php

# WHY
認証中時、扱いとしてはログインしているユーザーとなっているため、
メールアドレス誤り等で新規登録の再実施をしようとしても、認証中のweb表示から変更できないため、
ユーザーを切り替える為のボタンを設置。
ボタンの仕組みとしてはログアウトボタンであり、押下することで認証中ユーザーからログアウトして新たな登録処理や別ユーザーでのログインが可能となる。