### PR TITLE
メールアドレス変更時のメール認証

### DIFF
--- a/app/ChangeEmail.php
+++ b/app/ChangeEmail.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ChangeEmail extends Model
+{
+    protected $table       = 'change_email';
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -182,10 +182,24 @@ class UserController extends Controller
     public function userEmailUpdate(Request $request)
     {
       // メールからのアクセス
+      // http://127.0.0.1:8000/user/userEmailUpdate/?token=038ae6fddd76de23aff48226396c0c750185a26a28384632a8be86e5a1468732
       // トークン受け取り
+      $token = $request->input('token');
       // トークン照合
+      $email_change = DB::table('change_email')
+          ->where('update_token', '=', $token)
+          ->first();
       // 照合一致で一時保存DBのメールアドレスをDBメールアドレスに上書
+      $user = User::find($email_change->user_id);
+      $user->email = $email_change->new_email;
+      $user->save();
       // 一時保存DBレコード削除
+      DB::table('change_email')
+          ->where('update_token', '=', $token)
+          ->delete();
       // 変更完了通知
+      // (----あとで作成----)
+      // リダイレクト
+      return redirect('user');
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
 use Validator;
 use Mail;
+use DB;
 
 class UserController extends Controller
 {
@@ -141,33 +142,38 @@ class UserController extends Controller
       // 対象レコード取得
       $auth = Auth::user();
       // リクエストデータ受取
-      $address = $request->input('email');
+      $new_email = $request->input('email');
       // 同じメールアドレスで変更中ステータスがないか確認
       // あれば、古い変更中データは削除
       //
       // メール照合用トークン生成
-      $token = hash_hmac(
+      $update_token = hash_hmac(
         'sha256',
-        str_random(40).$address,
+        str_random(40).$new_email,
         env('APP_KEY')
       );
       // $domain = env('APP_DOMAIN');
       //
       // 変更データ一時保存DBへレコード保存
-      // $auth->fill($form)->save();
-      // return redirect('/user');
+      DB::table('change_email')->insert([
+        [
+            'user_id' => $auth->id,
+            'new_email' => $new_email,
+            'update_token' => $update_token
+        ]
+      ]);
       //
       // eval(\Psy\sh());
       // メール送付
       // !!!!一時保存DBのデータを引き渡してメールをおくる
       $user = Auth::user();
-      $user['token'] = $token;
+      $user['token'] = $update_token;
       // eval(\Psy\sh());
       // resources/views/vendor/notifications/email.blade.php
-      Mail::send('vendor/notifications/email', ['user' => $user], function ($message) use ($user, $address, $token) {
+      Mail::send('index', ['user' => $user], function ($message) use ($user, $new_email, $update_token) {
           // $message->priority($level);
           $message->from('hello@app.com', 'Your Application');
-          $message->to($address)->subject('Your Reminder!');
+          $message->to($new_email)->subject('Your Reminder!');
       });
       // Mail::raw('test mail',function($message) {$message->to('fippiy04@gmail.com')->subject('test');});
       return redirect('user');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -145,11 +145,17 @@ class UserController extends Controller
       // リクエストデータ受取
       $new_email = $request->input('email');
       // 変更前後でメールアドレスが同じか確認
-      // 同じ時は処理不要で中止
-      // (----あとで作成----)
-      // 同じメールアドレスで変更中ステータスがないか確認
-      // あれば、古い変更中データは削除して再申請orNG?
-      // (----あとで作成----)
+      $email_check = true;
+      if ($auth->email == $new_email) {
+        $email_check = false;
+      }
+      // メールアドレスが変更されていない時にエラーとして処理をかえす
+      $validator = Validator::make(['email' => $email_check], ['email' => 'accepted'], ['メールアドレスが変更されていません']);
+      if ($validator->fails()) {
+        return redirect('user/email')
+                    ->withErrors($validator)
+                    ->withInput();
+      }
       // メール照合用トークン生成
       $update_token = hash_hmac(
         'sha256',
@@ -169,7 +175,6 @@ class UserController extends Controller
           $message->to($change_email->new_email)->subject('メールアドレス確認');
       });
       return redirect('user');
-    // return [$auth, $form];
     }
     public function userEmailUpdate(Request $request)
     {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -128,4 +128,41 @@ class UserController extends Controller
       $auth = Auth::user();
       return view('user.edit',[ 'auth' => $auth, 'page' => $page ]);
     }
+    public function userEmailEdit()
+    {
+      $auth = Auth::user();
+      return view('user.email',[ 'auth' => $auth ]);
+    }
+    public function userEmailChange(Request $request)
+    {
+      // バリデーションチェック
+      $this->validate($request, User::$editEmailRules);
+      // 対象レコード取得
+      $auth = Auth::user();
+      // リクエストデータ受取
+      $form = $request->all();
+      // フォームトークン削除
+      unset($form['_token']);
+      // 同じメールアドレスで変更中ステータスがないか確認
+      // あれば、古い変更中データは削除
+      //
+      // メール照合用トークン生成
+      //
+      // 変更データ一時保存DBへレコード保存
+      // $auth->fill($form)->save();
+      // return redirect('/user');
+      //
+      // メール送付
+      //
+      return [$auth, $form];
+    }
+    public function userEmailUpdate(Request $request)
+    {
+      // メールからのアクセス
+      // トークン受け取り
+      // トークン照合
+      // 照合一致で一時保存DBのメールアドレスをDBメールアドレスに上書
+      // 一時保存DBレコード削除
+      // 変更完了通知
+    }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -164,25 +164,15 @@ class UserController extends Controller
       $change_email->save();
       // メール送付
       // !!!!一時保存DBのデータを引き渡してメールをおくる
-      $user = Auth::user();
-      $user['token'] = $update_token;
-      // eval(\Psy\sh());
-      // resources/views/vendor/notifications/email.blade.php
-      // メールフォーマット新規作成orテキストのみ送信？
-      // (----あとで作成----)
       $domain =env('APP_URL');
-      Mail::send('index', ['url' => "{$domain}/user/userEmailUpdate/?token={$update_token}"], function ($message) use ($change_email) {
-          $message->from('hello@app.com', 'Your Application');
-          $message->to($change_email->new_email)->subject('Your Reminder!');
+      Mail::send('email/change_email', ['url' => "{$domain}/user/userEmailUpdate/?token={$update_token}"], function ($message) use ($change_email) {
+          $message->to($change_email->new_email)->subject('メールアドレス確認');
       });
-      // Mail::raw('test mail',function($message) {$message->to('fippiy04@gmail.com')->subject('test');});
       return redirect('user');
     // return [$auth, $form];
     }
     public function userEmailUpdate(Request $request)
     {
-      // メールからのアクセス
-      // http://127.0.0.1:8000/user/userEmailUpdate/?token=038ae6fddd76de23aff48226396c0c750185a26a28384632a8be86e5a1468732
       // トークン受け取り
       $token = $request->input('token');
       // トークン照合
@@ -198,8 +188,10 @@ class UserController extends Controller
           ->where('update_token', '=', $token)
           ->delete();
       // 変更完了通知
-      // (----あとで作成----)
-      // リダイレクト
+      Mail::send('email/complete_email',[], function ($message) use ($user) {
+        $message->to($user->email)->subject('メールアドレス確認完了');
+      });
+    // リダイレクト
       return redirect('user');
     }
 }

--- a/database/migrations/2019_04_22_151346_create_change_email_table.php
+++ b/database/migrations/2019_04_22_151346_create_change_email_table.php
@@ -16,7 +16,7 @@ class CreateChangeEmailTable extends Migration
         Schema::create('change_email', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->integer('user_id');
-            $table->string('new_email')->unique();
+            $table->string('new_email');
             $table->text('update_token');
             $table->timestamps();
         });

--- a/database/migrations/2019_04_22_151346_create_change_email_table.php
+++ b/database/migrations/2019_04_22_151346_create_change_email_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateChangeEmailTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('change_email', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('change_email');
+    }
+}

--- a/database/migrations/2019_04_22_151346_create_change_email_table.php
+++ b/database/migrations/2019_04_22_151346_create_change_email_table.php
@@ -15,6 +15,9 @@ class CreateChangeEmailTable extends Migration
     {
         Schema::create('change_email', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->integer('user_id');
+            $table->text('new_email');
+            $table->text('update_token');
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_04_22_151346_create_change_email_table.php
+++ b/database/migrations/2019_04_22_151346_create_change_email_table.php
@@ -16,7 +16,7 @@ class CreateChangeEmailTable extends Migration
         Schema::create('change_email', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->integer('user_id');
-            $table->text('new_email');
+            $table->string('new_email')->unique();
             $table->text('update_token');
             $table->timestamps();
         });

--- a/resources/views/email/change_email.blade.php
+++ b/resources/views/email/change_email.blade.php
@@ -1,0 +1,5 @@
+book-property-management<br><br>
+新メールアドレス確認<br><br>
+新しいメールアドレスに変更します。<br>
+以下のURLをクリックして認証してください。<br>
+{{$url}}

--- a/resources/views/email/complete_email.blade.php
+++ b/resources/views/email/complete_email.blade.php
@@ -1,0 +1,2 @@
+book-property-management<br><br>
+メールアドレスの変更が完了しました。

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('user.edit',$auth) }}
+    {{ Breadcrumbs::render('edit.user',$auth) }}
   </div>
 @endsection
 
@@ -32,8 +32,8 @@
         @endif
       </div>
       <div class="book-new">
-        <form action="{{ route('update.user', $auth->id)}}" method="post" enctype="multipart/form-data">
-          {{ csrf_field() }}
+        <form action="{{ route('user.update', $auth->id)}}" method="post" enctype="multipart/form-data">
+        {{ csrf_field() }}
           <input type="hidden" name="_method" value="PUT">
           <input type="hidden" name="page" value="{{$page}}">
           <div class="form-contents">
@@ -42,12 +42,6 @@
               <div class="form-input">
                 <div class="form-label">ユーザー名</div>
                 <div><input class="form-input__input" type="text" name="name" value="{{$auth->name}}"></div>
-              </div>
-              @endif
-              @if ($page == 'email')
-              <div class="form-input">
-                <div class="form-label">メールアドレス</div>
-                <div><input class="form-input__input" type="text" name="email" value="{{$auth->email}}"></div>
               </div>
               @endif
               @if ($page == 'password')

--- a/resources/views/user/email.blade.php
+++ b/resources/views/user/email.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.layout')
+
+@section('title', 'EditForm')
+
+@section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('edit.user',$auth) }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_mypage')
+@endsection
+
+@section('content')
+<div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title mypage-color">
+        ユーザー情報編集
+      </div>
+      <div class="books-list__msg">
+        @foreach ($errors->all() as $error)
+          <p class="auth-contents__message--error">{{ $error }}</p>
+        @endforeach
+        @if (empty($error))
+          <p class="auth-contents__message--message">変更するデータを入力してください。</p>
+        @endif
+      </div>
+      <div class="book-new">
+        {{ route('email.change')}}
+        <form action="{{ route('email.change')}}" method="post" enctype="multipart/form-data">
+        {{ csrf_field() }}
+          <div class="form-contents">
+            <div class="form-one-size">
+              <div class="form-input">
+                <div class="form-label">メールアドレス</div>
+                <div><input class="form-input__input" type="text" name="email" value="{{$auth->email}}"></div>
+              </div>
+            </div>
+          </div>
+          <div class="form-foot">
+            <input class="send" type="submit" value="編集">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/user/email.blade.php
+++ b/resources/views/user/email.blade.php
@@ -32,7 +32,6 @@
         @endif
       </div>
       <div class="book-new">
-        {{ route('email.change')}}
         <form action="{{ route('email.change')}}" method="post" enctype="multipart/form-data">
         {{ csrf_field() }}
           <div class="form-contents">

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -32,17 +32,17 @@
           <div class="profile-group">
             <div class="profile-group__title">ユーザー名</div>
             <div class="profile-group__element">{{$auth->name}}</div>
-            <div class="profile-group__edit"><a href="{{ route('edit.user', 'name') }}">編集</a></div>
+            <div class="profile-group__edit"><a href="{{ route('user.edit', 'name') }}">編集</a></div>
           </div>
           <div class="profile-group">
             <div class="profile-group__title">メールアドレス</div>
             <div class="profile-group__element">{{$auth->email}}</div>
-            <div class="profile-group__edit"><a href="{{ route('edit.user', 'email') }}">編集</a></div>
+            <div class="profile-group__edit"><a href="{{ route('email.edit') }}">編集</a></div>
           </div>
           <div class="profile-group">
             <div class="profile-group__title">パスワード</div>
             <div class="profile-group__element">パスワードは安全の為表示できません。</div>
-            <div class="profile-group__edit"><a href="{{ route('edit.user', 'password') }}">編集</a></div>
+            <div class="profile-group__edit"><a href="{{ route('user.edit', 'password') }}">編集</a></div>
           </div>
           <div class="profile-group">
             <div class="profile-group__title">登録日時</div>

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -78,7 +78,7 @@ Breadcrumbs::for('user.index', function ($trail) {
 });
 
 // トップページ / マイページ / 編集：ユーザ
-Breadcrumbs::for('user.edit', function ($trail) {
+Breadcrumbs::for('edit.user', function ($trail) {
     $trail->parent('user.index');
-    $trail->push('編集', url('user.edit'));
+    $trail->push('編集', url('edit.user'));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,8 +29,10 @@ Route::group(['middleware' => ['verified']], function () {
   Route::get('/property/find', 'PropertyController@find')->name('property.find');
   Route::post('/property/find', 'PropertyController@search')->name('property.find');
   Route::resource('property', 'PropertyController');
-  Route::get('/user/{page}', 'UserController@useredit')->name('edit.user');
-  Route::post('/user/{page}', 'UserController@update')->name('update.user');
+  Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');
+  Route::post('/user/email', 'UserController@userEmailChange')->name('email.change');
+  Route::get('/user/{page}', 'UserController@useredit')->name('user.edit');
+  Route::post('/user/{page}', 'UserController@update')->name('user.update');
   Route::resource('user', 'UserController',['except' => ['show', 'edit']]);
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::resource('property', 'PropertyController');
   Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');
   Route::post('/user/email', 'UserController@userEmailChange')->name('email.change');
+  Route::get('/user/userEmailUpdate/', 'UserController@userEmailUpdate');
   Route::get('/user/{page}', 'UserController@useredit')->name('user.edit');
   Route::post('/user/{page}', 'UserController@update')->name('user.update');
   Route::resource('user', 'UserController',['except' => ['show', 'edit']]);


### PR DESCRIPTION
# WHAT
ユーザーのメールアドレス変更時にメールを送付して認証をする
## ChangeEmailモデル作成
### モデル作成
app/ChangeEmail.php
### マイグレーションファイル
database/migrations/2019_04_22_151346_create_change_email_table.php
### ビュー作成
resources/views/user/email.blade.php
### ルート追加
routes/web.php
## コントローラ、メール認証処理追加
app/Http/Controllers/UserController.php

## 送付メールテンプレート
resources/views/email/change_email.blade.php
resources/views/email/complete_email.blade.php
## editビュー、メールアドレス設定削除
resources/views/user/edit.blade.php
## ルート名修正
resources/views/user/index.blade.php
routes/breadcrumbs.php
# WHY
メールアドレス変更時のメール送付による認証を実装
メールアドレス変更アクションは既存の他のデータと処理が異なるため、editビューからは切り離し、新たに新規作成とした。
メールアドレス認証時のデータ一時保存にChangeEmailテーブルを新規作成。
新メールアドレスと照合用トークンを保存し、認証URLを新メールアドレスに送付するようにした。
メールアドレスを変更せずに変更処理をすると、エラーとして返しメールは送付しない。
認証URLへアクセスすると、ChangeEmail保存データと照合し、データが一致すればユーザーDBにメールアドレスを上書し、一時保存データを消去して変更完了となる。
変更完了時に完了メールを送付する。
