### PR TITLE
ユーザー情報削除

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -10,6 +10,7 @@ use Validator;
 use Mail;
 use DB;
 use App\ChangeEmail;
+use App\Property;
 
 class UserController extends Controller
 {
@@ -124,7 +125,11 @@ class UserController extends Controller
      */
     public function destroy($id)
     {
-      //
+      // 所有書籍削除
+      Property::where('user_id',$id)->delete();
+      // ユーザー削除
+      User::destroy($id);
+      return redirect('/');
     }
     public function useredit($page)
     {
@@ -198,5 +203,10 @@ class UserController extends Controller
       });
     // リダイレクト
       return redirect('user');
+    }
+    public function delete()
+    {
+      $auth = Auth::user();
+      return view('user.delete',[ 'auth' => $auth ]);
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -125,9 +125,6 @@ class UserController extends Controller
      */
     public function destroy($id)
     {
-      // 所有書籍削除
-      Property::where('user_id',$id)->delete();
-      // ユーザー削除
       User::destroy($id);
       return redirect('/');
     }

--- a/database/migrations/2019_04_08_220852_create_properties_table.php
+++ b/database/migrations/2019_04_08_220852_create_properties_table.php
@@ -15,12 +15,16 @@ class CreatePropertiesTable extends Migration
     {
         Schema::create('properties', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('user_id');
-            $table->integer('bookdata_id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('bookdata_id')->unsigned();
             $table->integer('number');
             $table->date('getdate')->nullable();
             $table->text('freememo')->nullable();
             $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
         });
     }
 

--- a/resources/views/components/menu_mypage.blade.php
+++ b/resources/views/components/menu_mypage.blade.php
@@ -4,7 +4,9 @@
       マイページトップ
     </div>
   </a>
-  <div class="tab mypage-color">
-    ユーザー情報削除
-  </div>
+  <a href="/user/delete">
+    <div class="tab mypage-color">
+      ユーザー情報削除
+    </div>
+  </a>
 </div>

--- a/resources/views/user/delete.blade.php
+++ b/resources/views/user/delete.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.layout')
+
+@section('title', 'Delete')
+
+@section('stylesheet')
+  <link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('user.delete') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_mypage')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title mypage-color">
+        ユーザー情報削除
+      </div>
+      <div class="book-table">
+        <div class="book-table__profile-list">
+        <div class="profile-group">
+            <div class="profile-group__element">ユーザー情報を削除するには、削除ボタンを押して下さい。</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">ユーザーID</div>
+            <div class="profile-group__element">{{$auth->id}}</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">ユーザー名</div>
+            <div class="profile-group__element">{{$auth->name}}</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">メールアドレス</div>
+            <div class="profile-group__element">{{$auth->email}}</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">パスワード</div>
+            <div class="profile-group__element">パスワードは安全の為表示できません。</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">登録日時</div>
+            <div class="profile-group__element">{{$auth->created_at}}</div>
+          </div>
+          <div class="profile-group">
+            <div class="profile-group__title">最終更新日時</div>
+            <div class="profile-group__element">{{$auth->updated_at}}</div>
+          </div>
+          <div class="book-new">
+            <form action="{{ route('user.destroy', $auth->id)}}" method="post" enctype="multipart/form-data">
+              <div class="form-foot">
+                {{ csrf_field() }}
+                <input type="hidden" name="_method" value="DELETE">
+                <input class="send" type="submit" value="削除">
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('edit.user',$auth) }}
+    {{ Breadcrumbs::render('user.edit',$auth) }}
   </div>
 @endsection
 

--- a/resources/views/user/email.blade.php
+++ b/resources/views/user/email.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('edit.user',$auth) }}
+    {{ Breadcrumbs::render('user.edit',$auth) }}
   </div>
 @endsection
 

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -78,7 +78,13 @@ Breadcrumbs::for('user.index', function ($trail) {
 });
 
 // トップページ / マイページ / 編集：ユーザ
-Breadcrumbs::for('edit.user', function ($trail) {
+Breadcrumbs::for('user.edit', function ($trail) {
     $trail->parent('user.index');
-    $trail->push('編集', url('edit.user'));
+    $trail->push('編集', url('user.edit'));
+});
+
+// トップページ / マイページ / ユーザ削除
+Breadcrumbs::for('user.delete', function ($trail) {
+    $trail->parent('user.index');
+    $trail->push('削除', url('user.delete'));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');
   Route::post('/user/email', 'UserController@userEmailChange')->name('email.change');
   Route::get('/user/userEmailUpdate/', 'UserController@userEmailUpdate');
+  Route::get('/user/delete', 'UserController@delete');
   Route::get('/user/{page}', 'UserController@useredit')->name('user.edit');
   Route::post('/user/{page}', 'UserController@update')->name('user.update');
   Route::resource('user', 'UserController',['except' => ['show', 'edit']]);


### PR DESCRIPTION
# WHAT
アプリ使用終了時にユーザー情報を削除する機能を実装する
## コントローラ、削除設定追加
app/Http/Controllers/UserController.php
## propertyテーブル、ユーザー削除連動設定追加
database/migrations/2019_04_08_220852_create_properties_table.php
## メニュー、リンク追加
resources/views/components/menu_mypage.blade.php
## ビュー、ユーザー削除ページ追加
resources/views/user/delete.blade.php
## ルーティング削除ビュールート追加
routes/web.php
## パンくずリスト修正
resources/views/user/edit.blade.php
resources/views/user/email.blade.php
routes/breadcrumbs.php

# WHY
ユーザー情報を削除するページを作成。
indexからいきなり削除は行わず、削除専用ページから削除を実施する形で作成。
削除実施時に関連する所有書籍情報を削除とするため、propertyテーブル上で外部キーを設定し、ユーザー削除時に同時に削除できるようにした。
