### PR TITLE
所有書籍登録バリデーションの実装

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -42,6 +42,9 @@ class PropertyController extends Controller
      */
     public function store(Request $request)
     {
+      // バリデーションチェック
+      $createPropertyRules = Property::PropertyRules();
+      $this->validate($request, $createPropertyRules);
       // 新規レコード生成
       $property = new Property;
       // リクエストデータ受取

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -43,7 +43,7 @@ class PropertyController extends Controller
     public function store(Request $request)
     {
       // バリデーションチェック
-      $createPropertyRules = Property::PropertyRules();
+      $createPropertyRules = Property::createPropertyRules();
       $this->validate($request, $createPropertyRules);
       // 新規レコード生成
       $property = new Property;

--- a/app/Property.php
+++ b/app/Property.php
@@ -35,4 +35,11 @@ class Property extends Model
                       ->get();
       return $notProperties;
   }
+  public function scopePropertyRules()
+  {
+    $createPropertyRules = array(
+      'bookdata_id' => 'required|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
+    );
+    return $createPropertyRules;
+  } 
 }

--- a/app/Property.php
+++ b/app/Property.php
@@ -35,7 +35,7 @@ class Property extends Model
                       ->get();
       return $notProperties;
   }
-  public function scopePropertyRules()
+  public function scopeCreatePropertyRules()
   {
     $createPropertyRules = array(
       'bookdata_id' => 'required|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,

--- a/resources/views/property/create.blade.php
+++ b/resources/views/property/create.blade.php
@@ -23,11 +23,12 @@
       <div class="books-list__title propertypage-color">
         所有書籍登録
       </div>
-      @if (isset($msg))
-        <div class="books-list__msg">
-            <span>{{$msg}}</span>
+      <div class="books-list__msg">
+      <p class="auth-contents__message--message">{{$msg}}</p>
+        @foreach ($errors->all() as $error)
+          <p class="auth-contents__message--error">{{ $error }}</p>
+        @endforeach
         </div>
-      @endif
       <div class="book-new">
         @if (isset($books) && count($books) != 0)
           <form action="/property" method="post" enctype="multipart/form-data">


### PR DESCRIPTION
# WHAT
所有書籍登録時の重複登録を防ぐため、バリデーションを実装する
## コントローラ、バリデーション設定追加
app/Http/Controllers/PropertyController.php
## モデル、バリデーションルール追加
app/Property.php
## ビュー、エラー表示対応
resources/views/property/create.blade.php

# WHY
所有書籍登録時のフォームには未登録書籍のみを表示しているが、登録ボタンを連続押下すると重複登録となっていた。
そのため、重複登録防止を目的としてバリデーションによる重複登録防止を実装した。

重複防止ルールをモデルに記載。ユーザーid取得を既存ルールの記載方法で使用すると取得できなかった為、記載方法をスコープに変更して取得している。
ビュー画面にてバリデーションエラー時のテキストを表示するエリアがなかったため、エラー表示を追加した。
