### PR TITLE
書籍リストに詳細内容テキスト表示を追加

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -136,7 +136,7 @@ class PropertyController extends Controller
       $properties = Property::where('user_id', Auth::user()->id)
                         ->join('bookdata','bookdata.id','=','properties.bookdata_id')
                         ->where('title', 'like', "%{$title}%")
-                        ->select('properties.id','title','picture','cover')
+                        ->select('properties.id','title','picture','cover','freememo')
                         ->get();
       $count = count($properties);
       if ($count==0) {

--- a/app/Property.php
+++ b/app/Property.php
@@ -24,7 +24,7 @@ class Property extends Model
   {
       $property = Property::where('user_id', Auth::user()->id)
                       ->join('bookdata','bookdata.id','=','properties.bookdata_id')
-                      ->select('properties.id','title','picture','cover')
+                      ->select('properties.id','title','picture','cover','freememo')
                       ->get();
       return $property;
   }

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -83,9 +83,16 @@
   height: 90px;
   width: 90px;
 }
-.index-content .books-list .book-table__list--detail .book-title {
+.index-content .books-list .book-table__list--detail {
+  padding-left: 10px;
+}
+.index-content .books-list .book-table__list--detail .list-book-title {
   font-size: 20px;
   color: blue;
+  margin-bottom: 10px;
+}
+.index-content .books-list .book-table__list--detail .list-book-detail {
+  margin-left: 10px;
 }
 .index-content .books-list .book-table__profile-list .profile-group {
   display: flex;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -80,9 +80,14 @@
           }
         }
         &--detail {
-          .book-title {
+          padding-left: 10px;
+          .list-book-title {
             font-size: 20px;
             color: blue;
+            margin-bottom: 10px;
+          }
+          .list-book-detail{
+            margin-left: 10px;
           }
         }
       }

--- a/resources/views/book/find.blade.php
+++ b/resources/views/book/find.blade.php
@@ -41,6 +41,9 @@
           @slot('page_path')
             book
           @endslot
+          @slot('detail')
+            detail
+          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -28,6 +28,9 @@
           @slot('page_path')
             book
           @endslot
+          @slot('detail')
+            detail
+          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -14,7 +14,8 @@
           </a>
         </div>
         <div class="book-table__list--detail">
-          <h3 class="book-title">{{$book->title}}</h3>
+          <a href="/{{$page_path}}/{{$book->id}}"><h3 class="list-book-title">{{$book->title}}</h3></a>
+          <p class="list-book-detail">{{ str_limit($book->$detail, $limit = 300, $end = '...') }}</p>
         </div>
       </div>
     @endforeach

--- a/resources/views/property/find.blade.php
+++ b/resources/views/property/find.blade.php
@@ -41,6 +41,9 @@
           @slot('page_path')
             property
           @endslot
+          @slot('detail')
+            freememo
+          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/property/index.blade.php
+++ b/resources/views/property/index.blade.php
@@ -28,6 +28,9 @@
           @slot('page_path')
             property
           @endslot
+          @slot('detail')
+            freememo
+          @endslot
         @endcomponent
       @endif
     </div>


### PR DESCRIPTION
# WHAT
書籍一覧情報に詳細情報を追加する
## カラム取得追加
app/Http/Controllers/PropertyController.php
app/Property.php
## スタイル設定追加
public/css/book-index.css
public/scss/book-index.scss
## ビュー表示、コンポーネントスロット追加
resources/views/book/find.blade.php
resources/views/book/index.blade.php
resources/views/property/find.blade.php
resources/views/property/index.blade.php
## コンポーネント、スロット対応
resources/views/components/books_list.blade.php

# WHY
booklistページに書籍詳細情報を表示する機能を追加した。
str_limitによって、テキスト表示上限を儲け、超過分は表示されない。
書籍情報では詳細情報を、所有書籍では登録メモを表示させる仕様としている。
フリーメモ表示の為にDBレコードjoinにfreememoを追加。
検索ページでも一覧表示を使用している為、あわせて設定追加を実施。

## 表示イメージ 2/2
書籍情報詳細 1/2
<img width="991" alt="スクリーンショット 2019-04-30 12 12 22" src="https://user-images.githubusercontent.com/45278393/56940590-5fc4dd80-6b4a-11e9-8dff-77853f009274.png">
所有書籍フリーメモ 2/2
<img width="989" alt="スクリーンショット 2019-04-30 12 12 32" src="https://user-images.githubusercontent.com/45278393/56940595-64899180-6b4a-11e9-947a-93e87dbd32cb.png">