### PR TITLE
bookdata登録失敗時をテストする

### DIFF
--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -51,8 +51,7 @@ class BookdataTest extends TestCase
         ];
         $response = $this->from('book/create')->post('book', $bookdata); // 本情報保存
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
-        $response->assertStatus(302); // リダイレクト
-        $response->assertRedirect('/book');  // トップページ表示
+        $response->assertStatus(200); // 200ステータスであること
 
         // 登録されていることの確認(indexページ)
         $response = $this->get('book'); // bookへアクセス
@@ -163,9 +162,29 @@ class BookdataTest extends TestCase
         $response = $this->get($find_post); // 編集ページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('book.find'); // book.editビューであること
-        $response = $this->from($find_post)->post($find_post, ['title' => $bookdata->title]); // 検索実施
+        $response = $this->from($find_post)->post($find_post, ['find' => $bookdata->title]); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200ステータスであること
         $response->assertSeeText($bookdata->title); // bookdataタイトルが表示されていること
+    }
+    // 登録タイトル未入力
+    public function test_bookControll_ng_entry()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 登録
+        $bookdata = [
+            'title' => '',
+            'detail' => '詳細はこちら',
+        ];
+        $response = $this->from('book/create')->post('book', $bookdata); // 本情報保存
+        $response->assertSessionHasErrors(['title']); // エラーメッセージがないこと
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('book/create');  // トップページ表示
+        $this->assertEquals('titleは必須です。',
+        session('errors')->first('title')); // エラメッセージを確認
     }
 }

--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -167,8 +167,12 @@ class BookdataTest extends TestCase
         $response->assertStatus(200); // 200ステータスであること
         $response->assertSeeText($bookdata->title); // bookdataタイトルが表示されていること
     }
-    // 登録タイトル未入力
-    public function test_bookControll_ng_entry()
+
+
+
+    //// NGパターン調査
+    // 手動登録タイトル未入力
+    public function test_bookControll_ng_notNameEntry()
     {
         //// ユーザー生成
         $user = factory(User::class)->create(); // ユーザーを作成
@@ -181,10 +185,85 @@ class BookdataTest extends TestCase
             'detail' => '詳細はこちら',
         ];
         $response = $this->from('book/create')->post('book', $bookdata); // 本情報保存
-        $response->assertSessionHasErrors(['title']); // エラーメッセージがないこと
+        $response->assertSessionHasErrors(['title']); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
         $response->assertRedirect('book/create');  // トップページ表示
         $this->assertEquals('titleは必須です。',
         session('errors')->first('title')); // エラメッセージを確認
+    }
+    // ISBN登録未入力
+    public function test_bookControll_ng_notIsbnEntry()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 登録
+        $bookdata = [
+            'isbn' => ''
+        ];
+        $response = $this->from('book/isbn')->post('book/isbn', $bookdata); // isbn登録
+        $response->assertSessionHasErrors(['isbn']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('book/isbn');  // 同ページ表示
+        $this->assertEquals('isbnは必須です。',
+        session('errors')->first('isbn')); // エラメッセージを確認
+    }
+    // ISBN登録桁数誤り小
+    public function test_bookControll_ng_IsbnSmallEntry()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 登録
+        $bookdata = [
+            'isbn' => '123456789012'
+        ];
+        $response = $this->from('book/isbn')->post('book/isbn', $bookdata); // isbn登録
+        $response->assertSessionHasErrors(['isbn']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('book/isbn');  // 同ページ表示
+        $this->assertEquals('isbnは13桁にしてください',
+        session('errors')->first('isbn')); // エラメッセージを確認
+    }
+    // ISBN登録桁数誤り大
+    public function test_bookControll_ng_IsbnBigEntry()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 登録
+        $bookdata = [
+            'isbn' => '12345678901234'
+        ];
+        $response = $this->from('book/isbn')->post('book/isbn', $bookdata); // isbn登録
+        $response->assertSessionHasErrors(['isbn']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('book/isbn');  // 同ページ表示
+        $this->assertEquals('isbnは13桁にしてください',
+        session('errors')->first('isbn')); // エラメッセージを確認
+    }
+    public function test_bookControll_ng_notIsbnData()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 登録
+        $bookdata = [
+            'isbn' => '1234567890123'
+        ];
+        $response = $this->from('book/isbn')->post('book/isbn', $bookdata); // isbn登録
+        $response->assertSessionHasErrors(['isbn']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('book/isbn');  // 同ページ表示
+        $this->assertEquals('該当するISBNコードは見つかりませんでした。',
+        session('errors')->first('isbn')); // エラメッセージを確認
     }
 }


### PR DESCRIPTION
# WHAT
bookdataテストを実装、新規登録失敗パターンをテストする
tests/Feature/BookdataTest.php

# WHY
## bookdata手動登録
タイトルを必須としており、未入力時のエラー出力を確認。
指定したエラーメッセージで表示されることをテスト

## isbn登録
ISBNコード入力を必須としており、未入力時のエラー出力を確認。
また、コードは13桁を必須とする為、12桁および14桁入力時のエラーを確認。
ISBNによる書籍情報検索結果がNG時もバリデーションエラーとして扱っている為、こちらについてもテストを行い、エラーメッセージ出力されていること確認した。
