### PR TITLE
メニュー表示スタイル修正

### DIFF
--- a/public/css/menulist.css
+++ b/public/css/menulist.css
@@ -6,7 +6,8 @@
   display: flex;
 }
 .menulist__menutab .tab {
-  width: 133px;
+  width: 200px;
+  font-size: 16px;
   height: 18px;
   margin: 3px 8px 0 0;
   padding: 9px 12px 5px 8px;

--- a/public/css/whole.css
+++ b/public/css/whole.css
@@ -1,3 +1,6 @@
+* {
+  font-family: "ヒラギノ角ゴ ProN", "ＭＳ　Ｐゴシック", sans-serif;
+}
 a {
   text-decoration: none;
   color: black;

--- a/public/scss/menulist.scss
+++ b/public/scss/menulist.scss
@@ -6,7 +6,8 @@
     border-bottom: 1px solid #000;
     display: flex;
     .tab {
-      width: 133px;
+      width: 200px;
+      font-size: 16px;
       height: 18px;
       margin: 3px 8px 0 0;
       padding: 9px 12px 5px 8px;

--- a/public/scss/whole.scss
+++ b/public/scss/whole.scss
@@ -1,3 +1,7 @@
+// フォント設定
+* {
+  font-family:"ヒラギノ角ゴ ProN","ＭＳ　Ｐゴシック",sans-serif;
+}
 // リンク設定
 a {
   text-decoration: none;


### PR DESCRIPTION
# WHAT
環境によって表示崩れが生じていた為、メニュー表示スタイルを修正する
## メニューリスト設定変更
public/css/menulist.css
public/scss/menulist.scss
## フォント種類指定追加
public/css/whole.css
public/scss/whole.scss
# WHY
Macによる開発を実施しているが、デプロイアプリをWindowsにて確認すると表示が崩れていた為、修正を実施。
サイト全体に対してフォント設定を追加。
表示崩れしているメニューに対してメニュー表示幅、フォントサイズ変更を実施
## 表示イメージ 2/2
修正前 Windows Chrome 1/2
![Win-index01](https://user-images.githubusercontent.com/45278393/57006440-d8e03580-6c1b-11e9-9ac8-cf10511dde12.JPG)
修正後 Windows Chrome 2/2
![Win-index08](https://user-images.githubusercontent.com/45278393/57006449-e8f81500-6c1b-11e9-932c-38dc761bcdde.JPG)
