### PR TITLE
書籍情報保護

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -6,6 +6,7 @@ use App\Bookdata;
 use Illuminate\Http\Request;
 use Aws\S3\S3Client;
 use Validator;
+use App\Property;
 
 class BookController extends Controller
 {
@@ -189,6 +190,18 @@ class BookController extends Controller
      */
     public function destroy($id)
     {
+      $have_property = Property::where('bookdata_id', $id)->first();
+      if (count($have_property) > 0) {
+        $have_book = false;
+      } else {
+        $have_book = true;
+      }
+      $validator = Validator::make(['bookdata_id' => $have_book], ['bookdata_id' => 'accepted'], ['所有者がいるため削除できません']);
+      if ($validator->fails()) {
+        return redirect('book/'.$id)
+                    ->withErrors($validator)
+                    ->withInput();
+      }
       // 画像保存ディレクトリ設定
       $save_directory = "book_images";
       // 削除レコード取得

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -61,7 +61,8 @@ class PropertyController extends Controller
       // 次の登録用フォームデータ取得
       // 所有書籍を除外して取得
       $notProperties = Property::userNothaveBook();
-      return view('property.create',['books'=>$notProperties, 'property'=>$property, 'msg'=>$msg]);    }
+      return view('property.create',['books'=>$notProperties, 'property'=>$property, 'msg'=>$msg]);
+    }
 
     /**
      * Display the specified resource.

--- a/database/migrations/2019_04_08_220852_create_properties_table.php
+++ b/database/migrations/2019_04_08_220852_create_properties_table.php
@@ -25,6 +25,8 @@ class CreatePropertiesTable extends Migration
             $table->foreign('user_id')
                 ->references('id')->on('users')
                 ->onDelete('cascade');
+            $table->foreign('bookdata_id')
+                ->references('id')->on('bookdata');
         });
     }
 

--- a/resources/views/book/show.blade.php
+++ b/resources/views/book/show.blade.php
@@ -31,6 +31,11 @@
           </form>
         </div>
       </div>
+      @foreach ($errors->all() as $error)
+      <div class="books-list__msg">
+        <p class="auth-contents__message--error">{{ $error }}</p>
+      </div>
+      @endforeach
       @include('components.book_detail')
     </div>
   </div>


### PR DESCRIPTION
# WHAT
書籍所有者がいる場合に、書籍データを削除できないようにする
## コントローラ、削除前のデータ判定を追加
app/Http/Controllers/BookController.php
## 記述修正
app/Http/Controllers/PropertyController.php
## データベース、外部キー設定追加
database/migrations/2019_04_08_220852_create_properties_table.php
## ビュー、エラーメッセージ表示追加
resources/views/book/show.blade.php

# WHY
所有者のいる本情報を削除できないように書籍情報ガード機能を追加。
Propertyテーブルにてbookdata_idの外部キーを設定。
書籍削除時のエラー対応としてバリデーション設定を追加。
エラー出力用にビューファイルに出力エリアを追加。
## 表示イメージ 1/1
<img width="1240" alt="スクリーンショット 2019-05-02 13 31 55" src="https://user-images.githubusercontent.com/45278393/57058151-0fd04d00-6ce9-11e9-9c17-9f66a510cb53.png">
