### PR TITLE
データベース設定修正

### DIFF
--- a/database/migrations/2019_04_08_220852_create_properties_table.php
+++ b/database/migrations/2019_04_08_220852_create_properties_table.php
@@ -16,7 +16,7 @@ class CreatePropertiesTable extends Migration
         Schema::create('properties', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id');
-            $table->integer('bookdata_id')->unsigned();
+            $table->unsignedInteger('bookdata_id');
             $table->integer('number');
             $table->date('getdate')->nullable();
             $table->text('freememo')->nullable();


### PR DESCRIPTION
# WHAT
デプロイ環境DB接続NGによる修正

# WHY
所有書籍新規登録がデプロイ環境のみ失敗する為、
マイグレーションファイルの型設定を修正