### PR TITLE
propertyテーブル 編集テスト

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -96,7 +96,9 @@ class PropertyController extends Controller
      */
     public function update(Request $request, $id)
     {
-      // バリデーションルール設定適用がいる
+      // バリデーションチェック
+      $createPropertyRules = Property::createPropertyRules();
+      $this->validate($request, $createPropertyRules);
       // 対象レコード取得
       $property = Property::find($id);
       // リクエストデータ受取

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -101,13 +101,16 @@ class PropertyController extends Controller
       $this->validate($request, $createPropertyRules);
       // 対象レコード取得
       $property = Property::find($id);
-      // リクエストデータ受取
-      $form = $request->all();
-      // フォームトークン削除
-      unset($form['_token']);
-      // レコードアップデート
-      $property->fill($form)->save();
-      return redirect('/property');
+      // 本人認証の上、更新処理
+      if ($property['user_id'] == Auth::user()->id){
+        // リクエストデータ受取
+        $form = $request->all();
+        // フォームトークン削除
+        unset($form['_token']);
+        // レコードアップデート
+        $property->fill($form)->save();
+      }
+        return redirect('/property');
     }
 
     /**

--- a/app/Property.php
+++ b/app/Property.php
@@ -38,7 +38,7 @@ class Property extends Model
   public function scopeCreatePropertyRules()
   {
     $createPropertyRules = array(
-      'bookdata_id' => 'required|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
+      'bookdata_id' => 'filled|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
     );
     return $createPropertyRules;
   } 

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -323,11 +323,34 @@ class PropertyTest extends TestCase
         $this->actingAs($user); // 選択ユーザーでログイン
         $this->assertTrue(Auth::check()); // Auth認証済であることを確認
 
-        //// 仮本新規登録
+        // 編集パス
         $propertypath = 'property/2/edit'; // 書籍編集パス(存在しないID)
 
         // アクセス不可
         $response = $this->get($propertypath); // ページにアクセス
+        $response->assertStatus(500);  // 500ステータスであること
+    }
+    public function test_propertyControll_ng_notIdDelete()
+    {
+        // property 自動生成 // 関連 user,bookdataも作成
+        factory(Property::class)->create();
+        
+        // ユーザーログイン
+        $user = User::first(); // 作成済みユーザー情報取得
+        $this->actingAs($user); // 選択ユーザーでログイン
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // 編集パス
+        $propertypath = 'property/2'; // 書籍編集パス(存在しないID)
+
+        // アクセス不可
+        $response = $this->get($propertypath); // ページにアクセス
+        $response->assertStatus(500);  // 500ステータスであること
+
+        //// 削除
+        $response = $this->from($propertypath)->post($propertypath, [
+            '_method' => 'DELETE',
+            ]); // 削除実施
         $response->assertStatus(500);  // 500ステータスであること
     }
 }

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -288,4 +288,28 @@ class PropertyTest extends TestCase
         $response = $this->from($propertydatapath)->post('property', $propertydata); // 本情報保存
         $response->assertStatus(500); // 500エラーであること
     }
+    // 所有書籍情報編集NG、タイトルなし
+    public function test_propertyControll_ng_notTitleEdit()
+    {
+        // property 自動生成 // 関連 user,bookdataも作成
+        $propertydata = factory(Property::class)->create();
+        
+        // ユーザーログイン
+        $user = User::first(); // 作成済みユーザー情報取得
+        $this->actingAs($user); // 選択ユーザーでログイン
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 仮本新規登録
+        $propertypath = 'property/'.$propertydata->id.'/edit'; // 書籍編集パス
+        //// 登録
+        $editpropertydata = [
+            'title' => '',
+        ]; // タイトルなしに編集
+        $response = $this->from($propertypath)->post('book', $editpropertydata); // 本情報保存
+        $response->assertSessionHasErrors(['title']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect($propertypath);  // トップページ表示
+        $this->assertEquals('titleは必須です。',
+        session('errors')->first('title')); // エラメッセージを確認
+    }
 }

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -353,7 +353,6 @@ class PropertyTest extends TestCase
                 ]);
             }
         }
-
         //// 編集パス
         $propertypath = 'property/11/edit'; // 書籍編集パス
         //// 登録
@@ -375,29 +374,5 @@ class PropertyTest extends TestCase
         $response->assertViewIs('property.index'); // indexビューであること
         $savebook = Property::find(11);
         $response->assertDontSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
-    }
-    // 未登録id削除
-    public function test_propertyControll_ng_notIdDelete()
-    {
-        // property 自動生成 // 関連 user,bookdataも作成
-        factory(Property::class)->create();
-        
-        // ユーザーログイン
-        $user = User::first(); // 作成済みユーザー情報取得
-        $this->actingAs($user); // 選択ユーザーでログイン
-        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
-
-        // 編集パス
-        $propertypath = 'property/2'; // 書籍編集パス(存在しないID)
-
-        // アクセス不可
-        $response = $this->get($propertypath); // ページにアクセス
-        $response->assertStatus(500);  // 500ステータスであること
-
-        //// 削除
-        $response = $this->from($propertypath)->post($propertypath, [
-            '_method' => 'DELETE',
-            ]); // 削除実施
-        $response->assertStatus(500);  // 500ステータスであること
     }
 }

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -357,22 +357,18 @@ class PropertyTest extends TestCase
         $propertypath = 'property/11/edit'; // 書籍編集パス
         //// 登録
         $editpropertydata = [
-            'bookdata_id' => 1,
             'number' => 11,
             '_method' => 'PUT',
         ]; // タイトルを編集
         $response = $this->from($propertypath)->post('property/11', $editpropertydata); // 本情報保存
-        $response->assertSessionHasErrors(['bookdata_id']); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
-        $response->assertRedirect('property/11/edit');  // トップページ表示
-        $this->assertEquals('bookdata idは既に存在します。',
-        session('errors')->first('bookdata_id')); // エラメッセージを確認
+        $response->assertRedirect('property');  // indexへリダイレクト
 
-        // 登録されていることの確認(indexページ)
-        $response = $this->get('property'); // indexへアクセス
-        $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // indexビューであること
+        // DBが変更されていないこと
         $savebook = Property::find(11);
-        $response->assertDontSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
+        $this->assertDatabaseHas('properties', [
+            'id' => $savebook->id,
+            'number' => $savebook->number,
+        ]); //DBに配列で指定した情報が残っていること
     }
 }

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -330,6 +330,7 @@ class PropertyTest extends TestCase
         $response = $this->get($propertypath); // ページにアクセス
         $response->assertStatus(500);  // 500ステータスであること
     }
+    // 未登録id削除
     public function test_propertyControll_ng_notIdDelete()
     {
         // property 自動生成 // 関連 user,bookdataも作成

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -312,4 +312,22 @@ class PropertyTest extends TestCase
         $this->assertEquals('titleは必須です。',
         session('errors')->first('title')); // エラメッセージを確認
     }
+    // 所有書籍情報編集NG、未登録id
+    public function test_propertyControll_ng_notIdEdit()
+    {
+        // property 自動生成 // 関連 user,bookdataも作成
+        $propertydata = factory(Property::class)->create();
+        
+        // ユーザーログイン
+        $user = User::first(); // 作成済みユーザー情報取得
+        $this->actingAs($user); // 選択ユーザーでログイン
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        //// 仮本新規登録
+        $propertypath = 'property/2/edit'; // 書籍編集パス(存在しないID)
+
+        // アクセス不可
+        $response = $this->get($propertypath); // ページにアクセス
+        $response->assertStatus(500);  // 500ステータスであること
+    }
 }

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -303,14 +303,15 @@ class PropertyTest extends TestCase
         $propertypath = 'property/'.$propertydata->id.'/edit'; // 書籍編集パス
         //// 編集
         $editpropertydata = [
-            'title' => '',
+            'bookdata_id' => '',
+            '_method' => 'PUT',
         ]; // タイトルなしに編集
         $response = $this->from($propertypath)->post('property/'.$propertydata->id, $editpropertydata); // 本情報保存
-        // $response->assertSessionHasErrors(['title']); // エラーメッセージがあること
-        // $response->assertStatus(302); // リダイレクト
-        // $response->assertRedirect($propertypath);  // トップページ表示
-        // $this->assertEquals('titleは必須です。',
-        // session('errors')->first('title')); // エラメッセージを確認
+        $response->assertSessionHasErrors(['bookdata_id']); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect($propertypath);  // トップページ表示
+        $this->assertEquals('bookdata idは必須です。',
+        session('errors')->first('bookdata_id')); // エラメッセージを確認
     }
     // 所有書籍情報編集NG、未登録id
     public function test_propertyControll_ng_notIdEdit()
@@ -364,18 +365,18 @@ class PropertyTest extends TestCase
             '_method' => 'PUT',
         ]; // タイトルを編集
         $response = $this->from($propertypath)->post('property/11', $editpropertydata); // 本情報保存
-        // $response->assertSessionHasErrors(['title']); // エラーメッセージがあること
+        $response->assertSessionHasErrors(['bookdata_id']); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
-        $response->assertRedirect('property');  // トップページ表示
-        // $this->assertEquals('titleは必須です。',
-        // session('errors')); // エラメッセージを確認
+        $response->assertRedirect('property/11/edit');  // トップページ表示
+        $this->assertEquals('bookdata idは既に存在します。',
+        session('errors')->first('bookdata_id')); // エラメッセージを確認
 
         // 登録されていることの確認(indexページ)
         $response = $this->get('property'); // propertyへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('property.index'); // property.indexビューであること
         $savebook = Property::find(11);
-        $response->assertSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
+        $response->assertDontSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
     }
     // 未登録id削除
     public function test_propertyControll_ng_notIdDelete()

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -41,7 +41,7 @@ class PropertyTest extends TestCase
         //// createページアクセス
         $response = $this->get('/property/create'); // createへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.create'); // book.createビューであること
+        $response->assertViewIs('property.create'); // createビューであること
 
         //// 所有書籍登録
         $propertydata = [
@@ -51,23 +51,22 @@ class PropertyTest extends TestCase
             'getdate' => '2000-01-01',
             'freememo' => 'testmemo',
         ];
-        $response = $this->from('property/create')->post('property', $propertydata); // 所有書籍保存
+        $response = $this->from('property/create')->post('property', $propertydata); // post送信
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200ステータスであること
 
         $savebook = Property::all()->first(); // 保存されたデータを取得
 
         // 登録されていることの確認(indexページ)
-        $response = $this->get('property'); // bookへアクセス
+        $response = $this->get('property'); // indexへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // book.indexビューであること
+        $response->assertViewIs('property.index'); // indexビューであること
         $response->assertSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
 
         // 詳細ページで表示されること
-        // $savebook = Bookdata::all()->first(); // 保存情報確認
-        $response = $this->get('property/'.$savebook['id']); // 指定bookへアクセス
+        $response = $this->get('property/'.$savebook['id']); // 指定ページへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.show'); // property.showビューであること
+        $response->assertViewIs('property.show'); // showビューであること
         foreach ($savebook as $value)
         {
             $response->assertSeeText($value);
@@ -75,9 +74,9 @@ class PropertyTest extends TestCase
 
         //// 編集
         $edit_post = 'property/'.$savebook['id']; // 編集パス
-        $response = $this->get($edit_post.'/edit'); // 編集ページへアクセス
+        $response = $this->get($edit_post.'/edit'); // editページへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.edit'); // property.editビューであること
+        $response->assertViewIs('property.edit'); // editビューであること
 
         // 編集内容
         $editpropertydata = [
@@ -91,12 +90,12 @@ class PropertyTest extends TestCase
         $response->assertStatus(302); // リダイレクト
         $response->assertRedirect('/property');  // トップページ表示
 
-        $editproperty = Property::all()->first(); // 編集されたデータを取得
+        $editproperty = Property::all()->first(); // editデータを取得
 
         // 編集されていることの確認(indexページ)
-        $response = $this->get('property'); // propertyへアクセス
+        $response = $this->get('property'); // indexへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // property.indexビューであること
+        $response->assertViewIs('property.index'); // indexビューであること
         $response->assertSeeText($editproperty->bookdata->title); // 編集タイトルが表示されていること
 
         //// 削除
@@ -108,10 +107,10 @@ class PropertyTest extends TestCase
         $response->assertRedirect('/property');  // トップページ表示
 
         // 削除されていることの確認(indexページ)
-        $response = $this->get('property'); // propertyへアクセス
+        $response = $this->get('property'); // indexへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // property.indexビューであること
-        $response->assertDontSeeText($editproperty->bookdata->title); // 削除タイトルが表示されていないこと
+        $response->assertViewIs('property.index'); // indexビューであること
+        $response->assertDontSeeText($editproperty->bookdata->title); // deleteタイトルが表示されていないこと
     }
     // 検索
     public function test_findTitle_ok_yesMatchFindTitle()
@@ -132,13 +131,13 @@ class PropertyTest extends TestCase
         //// 検索
         // 検索の実施(findページ)
         $find_post = 'property/find'; // 検索パス
-        $response = $this->get($find_post); // 検索ページへアクセス
+        $response = $this->get($find_post); // findページへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.find'); // property.findビューであること
+        $response->assertViewIs('property.find'); // findビューであること
         $response = $this->from($find_post)->post($find_post, ['find' => $propertydata->bookdata->title]); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertSeeText($propertydata->bookdata->title); // bookdataタイトルが表示されていること
+        $response->assertSeeText($propertydata->bookdata->title); // findタイトルが表示されていること
     }
     public function test_findTitle_ok_noMatchFindTitle()
     {
@@ -150,20 +149,20 @@ class PropertyTest extends TestCase
         // faker 自動生成
         $bookdata = factory(Bookdata::class)->create([
             'title' => 'a'
-        ]); // タイトル名aで作成
+        ]); // 指定タイトルで作成
         $propertydata = factory(Property::class)->create();
 
         //// 検索
         // 検索の実施(findページ)
-        $find_post = 'property/find'; // 検索パス
-        $response = $this->get($find_post); // 検索ページへアクセス
+        $find_post = 'property/find'; // findパス
+        $response = $this->get($find_post); // findページへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.find'); // property.findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => 'b']); // bで検索実施
+        $response->assertViewIs('property.find'); // findビューであること
+        $response = $this->from($find_post)->post($find_post, ['find' => 'b']); // 指定タイトル名で検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200 ステータスであること
-        $response->assertViewIs('property.find'); // property.findビューであること
-        $response->assertSeeText('書籍がみつかりませんでした。'); // タイトルなしメッセージが表示されていること
+        $response->assertViewIs('property.find'); // findビューであること
+        $response->assertSeeText('書籍がみつかりませんでした。'); // エラーメッセージが表示されていること
     }
     // 複数ユーザーによる複数書籍登録時のデータ表示確認
     public function test_propertySomeControll_ok()
@@ -193,9 +192,9 @@ class PropertyTest extends TestCase
         $savebooks = Property::where('user_id', $user->id)->get();
 
         // 選択ユーザーの所有書籍が登録されていることの確認
-        $response = $this->get('property'); // bookへアクセス
+        $response = $this->get('property'); // indexへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // book.indexビューであること
+        $response->assertViewIs('property.index'); // indexビューであること
         
         foreach ($savebooks as $savebook) {
             $response->assertSeeText($savebook->bookdata->title);
@@ -264,7 +263,7 @@ class PropertyTest extends TestCase
         $response->assertStatus(302); // リダイレクト
         $response->assertRedirect($savepropertypath);  // 同ページへリダイレクト
         $this->assertEquals('bookdata idは既に存在します。',
-        session('errors')->first('bookdata_id')); // エラメッセージを確認
+        session('errors')->first('bookdata_id')); // エラーメッセージを確認
     }
     // 別のユーザーで登録
     public function test_propertyControll_ng_unMatchUserEntry()
@@ -354,7 +353,6 @@ class PropertyTest extends TestCase
                 ]);
             }
         }
-        $testdata = Property::all();
 
         //// 編集パス
         $propertypath = 'property/11/edit'; // 書籍編集パス
@@ -372,9 +370,9 @@ class PropertyTest extends TestCase
         session('errors')->first('bookdata_id')); // エラメッセージを確認
 
         // 登録されていることの確認(indexページ)
-        $response = $this->get('property'); // propertyへアクセス
+        $response = $this->get('property'); // indexへアクセス
         $response->assertStatus(200); // 200ステータスであること
-        $response->assertViewIs('property.index'); // property.indexビューであること
+        $response->assertViewIs('property.index'); // indexビューであること
         $savebook = Property::find(11);
         $response->assertDontSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
     }


### PR DESCRIPTION
# WHAT
Propertyテーブル編集時のエラーパターンをテストする

# WHY
## テスト実装時に問題点を解消
propertyテーブル編集時のバリデーション未適用であった為、適用を併せて実施。
バリデーションルール、requireのまま実装すると編集時に問題発生の為、設定をfilledへ変更。
ログインユーザーでないproperty情報を直接編集できてしまっていたので、updateコントローラにユーザー制限を追加。
## テスト実装
タイトルなし(bookdata_idなし)時にエラーとしてはじかれることの確認。実際にbookdata_idを編集するフォームではないが、想定としてテストを実施。
タイトル変更(bookdata_id変更)についても同様に確認。
他人ユーザー所有情報をフォームより設定して編集しても失敗することの確認。
