### PR TITLE
所有書籍重複登録防止バリデーション設定変更

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -43,8 +43,8 @@ class PropertyController extends Controller
     public function store(Request $request)
     {
       // バリデーションチェック
-      $createPropertyRules = Property::createPropertyRules();
-      $this->validate($request, $createPropertyRules);
+      // $createPropertyRules = Property::createPropertyRules();
+      // $this->validate($request, $createPropertyRules);
       // 新規レコード生成
       $property = new Property;
       // リクエストデータ受取
@@ -97,8 +97,8 @@ class PropertyController extends Controller
     public function update(Request $request, $id)
     {
       // バリデーションチェック
-      $createPropertyRules = Property::createPropertyRules();
-      $this->validate($request, $createPropertyRules);
+      // $createPropertyRules = Property::createPropertyRules();
+      // $this->validate($request, $createPropertyRules);
       // 対象レコード取得
       $property = Property::find($id);
       // 本人認証の上、更新処理

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -46,9 +46,9 @@ class PropertyController extends Controller
       $user = Auth::user()->id; // ユーザー情報取得
       $form = $request->all(); // リクエストデータ受取
 
-      // 書籍情報nullチェック(登録時は必須、変更時は送信されないので除外)
+      // 書籍情報nullチェック
       $validator = Validator::make($form, [
-        'bookdata_id' => 'filled',
+        'bookdata_id' => 'required',
       ])->validate();
 
       // ユーザーの所有書籍に登録済みか確認

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -6,6 +6,7 @@ use App\User;
 use App\Property;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Validator;
 
 class PropertyController extends Controller
 {
@@ -42,21 +43,47 @@ class PropertyController extends Controller
      */
     public function store(Request $request)
     {
-      // バリデーションチェック
-      // $createPropertyRules = Property::createPropertyRules();
-      // $this->validate($request, $createPropertyRules);
+      $user = Auth::user()->id; // ユーザー情報取得
+      $form = $request->all(); // リクエストデータ受取
+
+      // 書籍情報nullチェック(登録時は必須、変更時は送信されないので除外)
+      $validator = Validator::make($form, [
+        'bookdata_id' => 'filled',
+      ])->validate();
+
+      // ユーザーの所有書籍に登録済みか確認
+      // ユーザー書籍取得
+      $entry_property = Property::where('user_id', $user)
+                        ->where('bookdata_id', $form['bookdata_id'])
+                        ->first();
+      // 書籍があればFalse
+      if (count($entry_property) == 0) {
+        $have_property = true;
+      } else {
+        $have_property = false;
+      }
+      // False時にエラーとして返す
+      $validator = Validator::make(['bookdata_id' => $have_property], ['bookdata_id' => 'accepted'], ['書籍は登録済みです']);
+      if ($validator->fails()) {
+        return redirect('property/create')
+                    ->withErrors($validator)
+                    ->withInput();
+      }
+
+      // バリデーションエラーなしで新規登録を実施
       // 新規レコード生成
       $property = new Property;
-      // リクエストデータ受取
-      $form = $request->all();
       // フォームトークン削除
       unset($form['_token']);
+
       // ユーザー情報追加
-      $form = $form + array('user_id' => strval(Auth::user()->id));
+      $form = $form + array('user_id' => strval($user));
+
       // DB保存
       $property->fill($form)->save();
       // 登録完了メッセージ
       $msg = "所有書籍を登録しました。";
+
       // 次の登録用フォームデータ取得
       // 所有書籍を除外して取得
       $notProperties = Property::userNothaveBook();
@@ -97,8 +124,8 @@ class PropertyController extends Controller
     public function update(Request $request, $id)
     {
       // バリデーションチェック
-      // $createPropertyRules = Property::createPropertyRules();
-      // $this->validate($request, $createPropertyRules);
+      $createPropertyRules = Property::createPropertyRules();
+      $this->validate($request, $createPropertyRules);
       // 対象レコード取得
       $property = Property::find($id);
       // 本人認証の上、更新処理

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -123,9 +123,6 @@ class PropertyController extends Controller
      */
     public function update(Request $request, $id)
     {
-      // バリデーションチェック
-      $createPropertyRules = Property::createPropertyRules();
-      $this->validate($request, $createPropertyRules);
       // 対象レコード取得
       $property = Property::find($id);
       // 本人認証の上、更新処理
@@ -134,6 +131,8 @@ class PropertyController extends Controller
         $form = $request->all();
         // フォームトークン削除
         unset($form['_token']);
+        // bookdataは変更しないので、送信されても削除
+        unset($form['bookdata_id']);
         // レコードアップデート
         $property->fill($form)->save();
       }

--- a/app/Property.php
+++ b/app/Property.php
@@ -35,13 +35,6 @@ class Property extends Model
                       ->get();
       return $notProperties;
   }
-  // public function scopeCreatePropertyRules()
-  // {
-  //   $createPropertyRules = array(
-  //     'bookdata_id' => 'filled|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
-  //   );
-  //   return $createPropertyRules;
-  // } 
   public static $searchRules = array(
     'find' => 'required'
   );

--- a/app/Property.php
+++ b/app/Property.php
@@ -35,13 +35,13 @@ class Property extends Model
                       ->get();
       return $notProperties;
   }
-  public function scopeCreatePropertyRules()
-  {
-    $createPropertyRules = array(
-      'bookdata_id' => 'filled|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
-    );
-    return $createPropertyRules;
-  } 
+  // public function scopeCreatePropertyRules()
+  // {
+  //   $createPropertyRules = array(
+  //     'bookdata_id' => 'filled|unique:properties,bookdata_id,NULL,user_id,user_id,'.Auth::user()->id,
+  //   );
+  //   return $createPropertyRules;
+  // } 
   public static $searchRules = array(
     'find' => 'required'
   );

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -262,7 +262,7 @@ class PropertyTest extends TestCase
         $response->assertSessionHasErrors(['bookdata_id']); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
         $response->assertRedirect($savepropertypath);  // 同ページへリダイレクト
-        $this->assertEquals('bookdata idは既に存在します。',
+        $this->assertEquals('書籍は登録済みです',
         session('errors')->first('bookdata_id')); // エラーメッセージを確認
     }
     // 別のユーザーで登録

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -287,7 +287,7 @@ class PropertyTest extends TestCase
         $response = $this->from($propertydatapath)->post('property', $propertydata); // 本情報保存
         $response->assertStatus(500); // 500エラーであること
     }
-    // 所有書籍情報編集NG、タイトルなし
+    // 所有書籍情報編集、bookdata_idを送信しても反映させない(他のカラムは反映)
     public function test_propertyControll_ng_notTitleEdit()
     {
         // property 自動生成 // 関連 user,bookdataも作成
@@ -303,14 +303,24 @@ class PropertyTest extends TestCase
         //// 編集
         $editpropertydata = [
             'bookdata_id' => '',
+            'number' => '100',
             '_method' => 'PUT',
         ]; // タイトルなしに編集
         $response = $this->from($propertypath)->post('property/'.$propertydata->id, $editpropertydata); // 本情報保存
-        $response->assertSessionHasErrors(['bookdata_id']); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
-        $response->assertRedirect($propertypath);  // トップページ表示
-        $this->assertEquals('bookdata idは必須です。',
-        session('errors')->first('bookdata_id')); // エラメッセージを確認
+        $response->assertRedirect('property');  // index表示
+
+        $response = $this->get('property'); // indexへアクセス
+        $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('property.index'); // indexビューであること
+        $savebook = Property::find(1);
+        $response->assertSeeText($savebook->bookdata->title); // 登録タイトルが表示されていること
+        
+        $response = $this->get('property/1'); // showへアクセス
+        $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('property.show'); // showビューであること
+        $response->assertSeeText('100'); // numberが反映されていること
+
     }
     // 所有書籍情報編集NG、未登録id
     public function test_propertyControll_ng_notIdEdit()


### PR DESCRIPTION
# WHAT
ユーザー自身の所有書籍を重複登録できないようにバリデーションを設定していたが修正を行う。

問題点
MySQLでは正常動作するが、PostgreSQLでエラーとなる。
<img width="399" alt="スクリーンショット 2019-05-02 12 46 37" src="https://user-images.githubusercontent.com/45278393/57604143-6a499300-759e-11e9-8caf-e2d4e03a043e.png">
この為、設定方法の見直しを実施。
## コントローラー再設定
app/Http/Controllers/PropertyController.php
## 不要となったスコープを削除
app/Property.php
## テストコード修正
tests/Feature/PropertyTest.php

# WHY
スコープのバリデーション設定を変更することで解決できなかったので、バリデーション設定方法を変更した。
## 新規追加時
所有書籍登録時に書籍情報は必須なので、初めに判定"required"
次に、ユーザーがすでに所持状態としていないか確認を実施。whereで書籍を検索。
検索し、書籍があればvalidatorによってエラーとする。
上記のエラーがなければ新規扱いとして登録作業を行う形として変更した。
このためスコープは削除し、アクション内でvalidatorを2つ作成する形に変更とした。

## 編集時
所有書籍の情報を編集するときの状態。このときの編集内容は所持数やユーザーメモが該当する。
所有書籍タイトルの変更はない。変更する場合は、新しい所有書籍を登録し、未所持書籍は削除となるべきであるため。
このため、フォームより所有書籍タイトルの変更は送信されないはずであるが、不正にデータ送信されることを懸念し、仮に送信されたbookdata_idがあれば削除する形に変更した。
