### PR TITLE
書籍情報ISBN複数登録対応

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -324,31 +324,13 @@ class BookController extends Controller
     }
 
     public function postIsbnSome(Request $request){
-        // バリデーションチェック
-        // $this->validate($request, Bookdata::$isbnEntryRules);
 
-        // $test_array = array(
-        //   'message1' => 'テスト',
-        //   'message2' => '本番',
-        // );
-        // return "こちらは$test_array[message2]環境です。"; // => 「こちらは本番環境です。」と出力される
-
-
+        // フォームデータ取得
         unset($request['_token']); // トークン削除
         $isbns = $request->all(); // isbnコードをフォームから取得
-        $count = count($isbns);
-        // $isbnapns = [];
-        // eval(\Psy\sh());e
-        // // isbnレコード配列を作成
-        // $i = 0;
-        // foreach($isbns as $value){
-        //   $isbnrecords[] = [
-        //     // 'record' => $i, // レコード番号、いらなそうなら消す
-        //     'isbn' => $value, // 取得isbnコード
-        //     'msg' => null, // msg格納用
-        //   ]; // 配列要素毎にisbn番号とメッセージ領域を格納
-        //   $i++;
-        // } 
+        $count = count($isbns); // 取得件数
+
+        // 処理用配列へ追加
         for ($i = 0; $i < $count; $i++){
           $isbnrecords[] = array(
             'number' => $i+1,
@@ -377,73 +359,24 @@ class BookController extends Controller
             }
           }
         }
-        // $isbnrecords
-        // eval(\Psy\sh());
 
         // ISBNコードから本情報を取得
         $isbn_url = 'https://api.openbd.jp/v1/get?isbn='; // API設定
         // 検索該当レコードのみデータ取得を実施
-        // foreach ($isbns as $isbn) {
         for ($i = 0; $i < $count; $i++){
           if ($isbnrecords[$i]['msg'] == null){ // メッセージ格納済みは対象外
             $isbn = $isbnrecords[$i]['isbn'];
-            $response = file_get_contents(
-                              $isbn_url.$isbn
-                        );
+            $response = file_get_contents($isbn_url.$isbn);
             $result = json_decode($response, true);
             data_set($isbnrecords[$i], 'result', $result); // 結果を格納
-            // eval(\Psy\sh());
-            // $getisbns[] = $result;
-
+            
             // ISBNレコード結果を確認
             // result[0]の情報有り無しで判定
             if($isbnrecords[$i]['result'][0] == null) {
               data_set($isbnrecords[$i], 'msg', '該当するISBNコードは見つかりませんでした。'); // 未登録時はメッセージ格納
-              // data_set($isbnrecords[$i], 'resultdata', false); // 結果を格納
-              // $isbndatas[] = false;
-            // } else {
-            //   data_set($isbnrecords[$i], 'resultdata', true); // 結果を格納
-            //   // $isbndatas[] = true;
-
-
-            // } else {
-            // //// この時点で必要な情報だけ加工すべき ////
-
-
             }
           }
         }
-        // return $isbnrecords;
-        // eval(\Psy\sh());
-
-
-        // eval(\Psy\sh());
-        // // ISBNコードから本情報を取得
-        // $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
-        // $response = file_get_contents(
-        //                   $isbn_url.$value
-        //             );
-        // $result = json_decode($response, true);
-
-
-        // // ISBNレコード結果を確認
-        // // result[0]の情報有り無しで判定
-        // if($result[0] == null)
-        // {
-        //   $isbndata = false;
-        // } else {
-        //   $isbndata = true;
-        // }
-
-        // // isbnレコード結果チェック
-        // // false時は検索結果なしで未登録とし、バリデーションエラーを返す
-        // $validator = Validator::make(['isbn' => $isbndata], ['isbn' => 'accepted'], ['該当するISBNコードは見つかりませんでした。']);
-        // if ($validator->fails()) {
-        //   return redirect('book/isbn')
-        //               ->withErrors($validator)
-        //               ->withInput();
-        // }
-
 
         // msgがnullのままの状態の物のみ登録する
         for ($i = 0; $i < $count; $i++){
@@ -454,7 +387,6 @@ class BookController extends Controller
 
             // summaryData取得
             $getdata = $isbnrecords[$i]['result'][0]["summary"];
-            // eval(\Psy\sh());
             // 要素毎にレコードに追加
             foreach($getdata as $key => $value){
               if(strlen($value) == 0){
@@ -472,24 +404,13 @@ class BookController extends Controller
             }
             // 保存
             $savedata->save();
-            // eval(\Psy\sh());
             data_set($isbnrecords[$i], 'result', $savedata); // 未登録時はメッセージ格納
             // 保存完了メッセージ
             data_set($isbnrecords[$i], 'msg', '登録しました'); // 未登録時はメッセージ格納
-            // $msg = 'データを新規作成しました。続けてISBNコードを登録できます。';
           }
         }
-        // $isbnrecords = json_encode( $isbnrecords , JSON_UNESCAPED_UNICODE) ;
-        // $isbnrecords = json_decode( $isbnrecords,true) ;
-        // $test = $isbnrecords[0]; 
-        // return $isbnrecords;
-        // eval(\Psy\sh());
+
         // ビューに出力
-        // return view('book.isbn',['msg'=>$msg,'book'=>$savedata]);
-        // return $isbnrecords;
-        // return view('book.isbn_some',['answers' => $isbnrecords,'msg' => null, 'book' => null]);
         return view('book.isbn_result',['answers' => $isbnrecords]);
-        // return view('book.isbn',compact($isbnrecords));
-        // return view('book.isbn',['answer' => $isbnrecords,'msg' => null, 'book' => null]);
     }
 }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -351,7 +351,7 @@ class BookController extends Controller
         // } 
         for ($i = 0; $i < $count; $i++){
           $isbnrecords[] = array(
-            // 'number' => $i,
+            'number' => $i+1,
             'isbn' => $isbns['isbn'.$i],
             'msg' => null,
           );
@@ -473,6 +473,7 @@ class BookController extends Controller
             }
             // 保存
             $savedata->save();
+            // eval(\Psy\sh());
             data_set($isbnrecords[$i], 'result', $savedata); // 未登録時はメッセージ格納
             // 保存完了メッセージ
             data_set($isbnrecords[$i], 'msg', '登録しました'); // 未登録時はメッセージ格納
@@ -487,8 +488,8 @@ class BookController extends Controller
         // ビューに出力
         // return view('book.isbn',['msg'=>$msg,'book'=>$savedata]);
         // return $isbnrecords;
-
-        return view('book.isbn_some',['answers' => $isbnrecords,'msg' => null, 'book' => null]);
+        // return view('book.isbn_some',['answers' => $isbnrecords,'msg' => null, 'book' => null]);
+        return view('book.isbn_result',['answers' => $isbnrecords]);
         // return view('book.isbn',compact($isbnrecords));
         // return view('book.isbn',['answer' => $isbnrecords,'msg' => null, 'book' => null]);
     }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -255,13 +255,17 @@ class BookController extends Controller
     public function getIsbn(){
       $msg = 'ISBNコードを入力して下さい。';
       return view('book.isbn',['msg'=>$msg]);
-  }
+    }
+    public function getIsbnSome(){
+      $msg = 'ISBNコードを入力して下さい。';
+      return view('book.isbn_some',['msg'=>$msg]);
+    }
     public function postIsbn(Request $request){
-        // バリデーションチェック
-        $this->validate($request, Bookdata::$isbnEntryRules);
+              // バリデーションチェック
+              $this->validate($request, Bookdata::$isbnEntryRules);
 
-        unset($request['_token']);
-        $value = $request['isbn'];
+              unset($request['_token']);
+              $value = $request['isbn'];
 
         // ISBNコードから本情報を取得
         $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
@@ -317,5 +321,175 @@ class BookController extends Controller
         $msg = 'データを新規作成しました。続けてISBNコードを登録できます。';
         // ビューに出力
         return view('book.isbn',['msg'=>$msg,'book'=>$savedata]);
+    }
+
+    public function postIsbnSome(Request $request){
+        // バリデーションチェック
+        // $this->validate($request, Bookdata::$isbnEntryRules);
+
+        // $test_array = array(
+        //   'message1' => 'テスト',
+        //   'message2' => '本番',
+        // );
+        // return "こちらは$test_array[message2]環境です。"; // => 「こちらは本番環境です。」と出力される
+
+
+        unset($request['_token']); // トークン削除
+        $isbns = $request->all(); // isbnコードをフォームから取得
+        $count = count($isbns);
+        // $isbnapns = [];
+        // eval(\Psy\sh());e
+        // // isbnレコード配列を作成
+        // $i = 0;
+        // foreach($isbns as $value){
+        //   $isbnrecords[] = [
+        //     // 'record' => $i, // レコード番号、いらなそうなら消す
+        //     'isbn' => $value, // 取得isbnコード
+        //     'msg' => null, // msg格納用
+        //   ]; // 配列要素毎にisbn番号とメッセージ領域を格納
+        //   $i++;
+        // } 
+        for ($i = 0; $i < $count; $i++){
+          $isbnrecords[] = array(
+            // 'number' => $i,
+            'isbn' => $isbns['isbn'.$i],
+            'msg' => null,
+          );
+        }
+
+        // フォームデータ評価
+        for ($i = 0; $i < $count; $i++){
+          if ($isbnrecords[$i]['msg'] == null){ // メッセージ格納済みは対象外
+            if (mb_strlen($isbnrecords[$i]['isbn']) == null){
+              data_set($isbnrecords[$i], 'msg', 'ISBNが登録されていません'); // 未登録時はメッセージ格納
+            } elseif (mb_strlen($isbnrecords[$i]['isbn']) != 13){
+              data_set($isbnrecords[$i], 'msg', '桁数が13桁ではありません。'); // 13桁でない場合はメッセージ格納
+            } else {
+              for ($j = $i+1; $j < $count; $j++){
+                if ($isbnrecords[$i]['isbn'] == $isbnrecords[$j]['isbn']) {
+                  data_set($isbnrecords[$j], 'msg', ($i+1)."件目のデータと同じです。"); // フォームデータ重複チェック
+                }
+              }
+            }
+            // DBユニークチェック
+            if (Bookdata::where('isbn', $isbnrecords[$i]['isbn'])->first() != null){
+              data_set($isbnrecords[$i], 'msg', '既に登録されています。'); // DB存在時はメッセージ格納
+            }
+          }
+        }
+        // $isbnrecords
+        // eval(\Psy\sh());
+
+        // ISBNコードから本情報を取得
+        $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
+
+        // 検索該当レコードのみデータ取得を実施
+        // foreach ($isbns as $isbn) {
+        for ($i = 0; $i < $count; $i++){
+          if ($isbnrecords[$i]['msg'] == null){ // メッセージ格納済みは対象外
+            $isbn = $isbnrecords[$i]['isbn'];
+            $response = file_get_contents(
+                              $isbn_url.$isbn
+                        );
+            $result = json_decode($response, true);
+            data_set($isbnrecords[$i], 'result', $result); // 結果を格納
+            // eval(\Psy\sh());
+            // $getisbns[] = $result;
+
+            // ISBNレコード結果を確認
+            // result[0]の情報有り無しで判定
+            if($isbnrecords[$i]['result'][0] == null) {
+              data_set($isbnrecords[$i], 'msg', '該当するISBNコードは見つかりませんでした。'); // 未登録時はメッセージ格納
+              // data_set($isbnrecords[$i], 'resultdata', false); // 結果を格納
+              // $isbndatas[] = false;
+            // } else {
+            //   data_set($isbnrecords[$i], 'resultdata', true); // 結果を格納
+            //   // $isbndatas[] = true;
+
+
+            // } else {
+            // //// この時点で必要な情報だけ加工すべき ////
+
+
+            }
+          }
+        }
+        // return $isbnrecords;
+        // eval(\Psy\sh());
+
+
+        // eval(\Psy\sh());
+        // // ISBNコードから本情報を取得
+        // $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
+        // $response = file_get_contents(
+        //                   $isbn_url.$value
+        //             );
+        // $result = json_decode($response, true);
+
+
+        // // ISBNレコード結果を確認
+        // // result[0]の情報有り無しで判定
+        // if($result[0] == null)
+        // {
+        //   $isbndata = false;
+        // } else {
+        //   $isbndata = true;
+        // }
+
+        // // isbnレコード結果チェック
+        // // false時は検索結果なしで未登録とし、バリデーションエラーを返す
+        // $validator = Validator::make(['isbn' => $isbndata], ['isbn' => 'accepted'], ['該当するISBNコードは見つかりませんでした。']);
+        // if ($validator->fails()) {
+        //   return redirect('book/isbn')
+        //               ->withErrors($validator)
+        //               ->withInput();
+        // }
+
+
+        // msgがnullのままの状態の物のみ登録する
+        for ($i = 0; $i < $count; $i++){
+          if ($isbnrecords[$i]['msg'] == null){ // メッセージ格納済みは対象外
+
+            // ISBNレコードがあれば追加処理
+            $savedata = new Bookdata;
+
+            // summaryData取得
+            $getdata = $isbnrecords[$i]['result'][0]["summary"];
+            // eval(\Psy\sh());
+            // 要素毎にレコードに追加
+            foreach($getdata as $key => $value){
+              if(strlen($value) == 0){
+                $savedata->$key = null;
+              } else {
+                $savedata->$key = $value;
+              }
+            }
+            // detail取得
+            $detail_datacheck = empty($isbnrecords[$i]['result'][0]["onix"]["DescriptiveDetail"]["Contributor"][0]["BiographicalNote"]);
+            if(strlen($detail_datacheck) == true){
+              $savedata->detail = null;
+            } else {
+              $savedata->detail = $isbnrecords[$i]['result'][0]["onix"]["DescriptiveDetail"]["Contributor"][0]["BiographicalNote"];
+            }
+            // 保存
+            $savedata->save();
+            data_set($isbnrecords[$i], 'result', $savedata); // 未登録時はメッセージ格納
+            // 保存完了メッセージ
+            data_set($isbnrecords[$i], 'msg', '登録しました'); // 未登録時はメッセージ格納
+            // $msg = 'データを新規作成しました。続けてISBNコードを登録できます。';
+          }
+        }
+        // $isbnrecords = json_encode( $isbnrecords , JSON_UNESCAPED_UNICODE) ;
+        // $isbnrecords = json_decode( $isbnrecords,true) ;
+        // $test = $isbnrecords[0]; 
+        // return $isbnrecords;
+        // eval(\Psy\sh());
+        // ビューに出力
+        // return view('book.isbn',['msg'=>$msg,'book'=>$savedata]);
+        // return $isbnrecords;
+
+        return view('book.isbn_some',['answers' => $isbnrecords,'msg' => null, 'book' => null]);
+        // return view('book.isbn',compact($isbnrecords));
+        // return view('book.isbn',['answer' => $isbnrecords,'msg' => null, 'book' => null]);
     }
 }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -261,11 +261,11 @@ class BookController extends Controller
       return view('book.isbn_some',['msg'=>$msg]);
     }
     public function postIsbn(Request $request){
-              // バリデーションチェック
-              $this->validate($request, Bookdata::$isbnEntryRules);
+        // バリデーションチェック
+        $this->validate($request, Bookdata::$isbnEntryRules);
 
-              unset($request['_token']);
-              $value = $request['isbn'];
+        unset($request['_token']);
+        $value = $request['isbn'];
 
         // ISBNコードから本情報を取得
         $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
@@ -381,8 +381,7 @@ class BookController extends Controller
         // eval(\Psy\sh());
 
         // ISBNコードから本情報を取得
-        $isbn_url = 'https://api.openbd.jp/v1/get?isbn=';
-
+        $isbn_url = 'https://api.openbd.jp/v1/get?isbn='; // API設定
         // 検索該当レコードのみデータ取得を実施
         // foreach ($isbns as $isbn) {
         for ($i = 0; $i < $count; $i++){

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -207,3 +207,35 @@
   color: #fff;
   font-size: 18px;
 }
+.index-content .books-list .isbn-result {
+  margin-top: 20px;
+}
+.index-content .books-list .isbn-result__box {
+  width: 100%;
+  height: 100px;
+  display: flex;
+  border-bottom: 1px solid black;
+  padding: 5px;
+}
+.index-content .books-list .isbn-result__box--number {
+  width: 30px;
+  padding: 10px;
+  text-align: center;
+  line-height: 100px;
+}
+.index-content .books-list .isbn-result__box--bottom {
+  border-top: 1px dashed black;
+  display: flex;
+}
+.index-content .books-list .isbn-result__box--image {
+  padding: 5px 0 5px;
+  width: 100px;
+  line-height: 90px;
+}
+.index-content .books-list .isbn-result__box--image img {
+  height: 80px;
+  width: 60px;
+}
+.index-content .books-list .isbn-result__box--title {
+  line-height: 90px;
+}

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -213,5 +213,37 @@
         }
       }
     }
+    .isbn-result {
+      margin-top: 20px;
+      &__box {
+        width: 100%;
+        height: 100px;
+        display: flex;
+        border-bottom: 1px solid black;
+        padding: 5px;
+        &--number {
+          width: 30px;
+          padding: 10px;
+          text-align: center;
+          line-height: 100px;
+        }
+        &--bottom {
+          border-top: 1px dashed black;
+          display: flex;
+        }
+        &--image {
+          padding: 5px 0 5px;
+          width: 100px;
+          line-height: 90px;
+          img {
+            height: 80px;
+            width: 60px;
+          }
+        }
+        &--title {
+          line-height: 90px;
+        }
+      }
+    }
   }
 }

--- a/resources/views/book/isbn_result.blade.php
+++ b/resources/views/book/isbn_result.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.layout')
+
+@section('title', 'ISBN')
+
+@section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('book.isbn_some') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title bookpage-color">
+        ISBNコード登録結果
+      </div>
+
+      <div class="isbn-result">
+        @foreach ($answers as $answer)
+        <div class="isbn-result__box">
+          <div class="isbn-result__box--number">{{$answer['number']}}</div>
+          <div class="isbn-result__box--detail">
+            <div class="isbn-result__box--head">
+              <span class="isbn-result__box--isbn">{{$answer['isbn']}}</span>
+              <span class="isbn-result__box--msg">{{$answer['msg']}}</span>
+            </div>
+            @if (isset($answer['result']))
+            <div class="isbn-result__box--bottom">
+              <div class="isbn-result__box--image">
+              @if (isset($answer['result']['cover']) == null)
+                <img src="../image/no-entry.jpg">
+              @else
+                <img src="{{$answer['result']['cover']}}">
+              @endif
+              </div>
+              <div class="isbn-result__box--title">{{$answer['result']['title']}}</div>
+            </div>
+            @endif
+          </div>
+        </div>
+        @endforeach
+
+    </div>
+  </div>
+@endsection

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.layout')
+
+@section('title', 'ISBN')
+
+@section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('book.isbn') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title bookpage-color">
+        ISBNコード登録
+      </div>
+      <div class="books-list__msg">
+        @foreach ($errors->all() as $error)
+        <p class="auth-contents__message--error">{{ $error }}</p>
+        @endforeach
+      </div>
+      <div class="book-new">
+        <form action="/book/isbn_some" method="post">
+          {{ csrf_field() }}
+          <div class="form-contents">
+            <div class="form-input form-one-size">
+              <div class="form-label">ISBNコード</div>
+              <!-- <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div> -->
+              <!-- @for ($i = 0; $i < 10; $i++)
+                <div><input class="form-input__input" type="number" name="isbn{{$i}}" value="9784756918765"></div>
+              @endfor -->
+              <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
+              <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div>
+              <div><input class="form-input__input" type="number" name="isbn2" value="9784844366454"></div>
+              <div><input class="form-input__input" type="number" name="isbn3" value="9784798052588"></div>
+              <div><input class="form-input__input" type="number" name="isbn4" value="9784863542174"></div>
+              <div><input class="form-input__input" type="number" name="isbn5" value="9784054066892"></div>
+              <div><input class="form-input__input" type="number" name="isbn6" value="9784756918765"></div>
+              <div><input class="form-input__input" type="number" name="isbn7" value="9784756918765"></div>
+              <div><input class="form-input__input" type="number" name="isbn8" value=""></div>
+              <div><input class="form-input__input" type="number" name="isbn9" value=""></div>
+            </div>
+          </div>
+          <div class="form-foot">
+            <input class="send isbn" type="submit" value="登録">
+          </div>
+        </form>
+      </div>
+      <div class="book-new">
+      </div>
+    </div>
+  </div>
+  @if (isset($answers))
+    @foreach ($answers as $answer)
+      {{$answer['isbn']}}
+      {{$answer['msg']}}
+      @if (isset($answer['result']))
+        {{$answer['result']}}
+      @endif
+      <br><br>
+    @endforeach
+  @endif
+ @endsection

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -24,6 +24,7 @@
         ISBNコード登録
       </div>
       <div class="books-list__msg">
+        <p class="auth-contents__message--message">{{ $msg }}</p>
         @foreach ($errors->all() as $error)
         <p class="auth-contents__message--error">{{ $error }}</p>
         @endforeach
@@ -34,20 +35,14 @@
           <div class="form-contents">
             <div class="form-input form-one-size">
               <div class="form-label">ISBNコード</div>
-              <!-- <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div> -->
               <!-- @for ($i = 0; $i < 10; $i++)
-                <div><input class="form-input__input" type="number" name="isbn{{$i}}" value="9784756918765"></div>
+                <div><input class="form-input__input" type="number" name="isbn{{$i}}"></div>
               @endfor -->
               <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
               <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div>
               <div><input class="form-input__input" type="number" name="isbn2" value="9784844366454"></div>
-              <div><input class="form-input__input" type="number" name="isbn3" value="9784798052588"></div>
-              <div><input class="form-input__input" type="number" name="isbn4" value="9784863542174"></div>
-              <div><input class="form-input__input" type="number" name="isbn5" value="9784054066892"></div>
-              <div><input class="form-input__input" type="number" name="isbn6" value="9784756918765"></div>
-              <div><input class="form-input__input" type="number" name="isbn7" value="9784756918765"></div>
-              <div><input class="form-input__input" type="number" name="isbn8" value=""></div>
-              <div><input class="form-input__input" type="number" name="isbn9" value=""></div>
+              <div><input class="form-input__input" type="number" name="isbn3" value="9784797398892"></div>
+              <div><input class="form-input__input" type="number" name="isbn4" value="9784797398892"></div>
             </div>
           </div>
           <div class="form-foot">
@@ -55,18 +50,6 @@
           </div>
         </form>
       </div>
-      <div class="book-new">
-      </div>
     </div>
   </div>
-  @if (isset($answers))
-    @foreach ($answers as $answer)
-      {{$answer['isbn']}}
-      {{$answer['msg']}}
-      @if (isset($answer['result']))
-        {{$answer['result']}}
-      @endif
-      <br><br>
-    @endforeach
-  @endif
- @endsection
+@endsection

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -41,8 +41,13 @@
               <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
               <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div>
               <div><input class="form-input__input" type="number" name="isbn2" value="9784844366454"></div>
-              <div><input class="form-input__input" type="number" name="isbn3" value="9784797398892"></div>
-              <div><input class="form-input__input" type="number" name="isbn4" value="9784797398892"></div>
+              <div><input class="form-input__input" type="number" name="isbn3" value="9784798052588"></div>
+              <div><input class="form-input__input" type="number" name="isbn4" value="9784863542174"></div>
+              <div><input class="form-input__input" type="number" name="isbn5" value="9784054066892"></div>
+              <div><input class="form-input__input" type="number" name="isbn6" value="9784756918765"></div>
+              <div><input class="form-input__input" type="number" name="isbn7" value="9784756918765"></div>
+              <div><input class="form-input__input" type="number" name="isbn8" value=""></div>
+              <div><input class="form-input__input" type="number" name="isbn9" value=""></div>
             </div>
           </div>
           <div class="form-foot">

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -35,10 +35,10 @@
           <div class="form-contents">
             <div class="form-input form-one-size">
               <div class="form-label">ISBNコード</div>
-              <!-- @for ($i = 0; $i < 10; $i++)
+              @for ($i = 0; $i < 10; $i++)
                 <div><input class="form-input__input" type="number" name="isbn{{$i}}"></div>
-              @endfor -->
-              <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
+              @endfor
+              <!-- <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
               <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div>
               <div><input class="form-input__input" type="number" name="isbn2" value="9784844366454"></div>
               <div><input class="form-input__input" type="number" name="isbn3" value="9784798052588"></div>
@@ -47,7 +47,7 @@
               <div><input class="form-input__input" type="number" name="isbn6" value="9784756918765"></div>
               <div><input class="form-input__input" type="number" name="isbn7" value="9784756918765"></div>
               <div><input class="form-input__input" type="number" name="isbn8" value=""></div>
-              <div><input class="form-input__input" type="number" name="isbn9" value=""></div>
+              <div><input class="form-input__input" type="number" name="isbn9" value=""></div> -->
             </div>
           </div>
           <div class="form-foot">

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('book.isbn') }}
+    {{ Breadcrumbs::render('book.isbn_some') }}
   </div>
 @endsection
 

--- a/resources/views/components/menu_book.blade.php
+++ b/resources/views/components/menu_book.blade.php
@@ -11,7 +11,12 @@
   </a>
   <a href="/book/isbn">
     <div class="tab bookpage-color">
-      ISBNコード登録
+      ISBNコード登録(単体)
+    </div>
+  </a>
+  <a href="/book/isbn_some">
+    <div class="tab bookpage-color">
+      ISBNコード登録(複数)
     </div>
   </a>
   <a href="/book/find">

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -17,10 +17,16 @@ Breadcrumbs::for('book.create', function ($trail) {
     $trail->push('新規登録', url('book.create'));
 });
 
-// トップページ / 書籍 / 新規登録(ISBN)
+// トップページ / 書籍 / ISBN登録(単体)
 Breadcrumbs::for('book.isbn', function ($trail) {
     $trail->parent('book.index');
-    $trail->push('新規登録(ISBN)', url('book.isbn'));
+    $trail->push('ISBN登録(単体)', url('book.isbn'));
+});
+
+// トップページ / 書籍 / ISBN登録(複数)
+Breadcrumbs::for('book.isbn_some', function ($trail) {
+    $trail->parent('book.index');
+    $trail->push('ISBN登録(複数)', url('book.isbn_some'));
 });
 
 // トップページ / 書籍 / 詳細

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ Auth::routes(['verify' => true]);
 Route::group(['middleware' => ['verified']], function () {
   Route::get('/book/isbn', 'BookController@getIsbn');
   Route::post('/book/isbn', 'BookController@postIsbn');
+  Route::get('/book/isbn_some', 'BookController@getIsbnSome');
+  Route::post('/book/isbn_some', 'BookController@postIsbnSome');
   Route::get('/book/find', 'BookController@find')->name('book.find');
   Route::post('/book/find', 'BookController@search')->name('book.find');
   Route::resource('book', 'BookController');


### PR DESCRIPTION
# WHAT
ISBNによる書籍情報登録について、複数コード一括登録を実装する
## コントローラ、複数ISBN登録処理を追加
app/Http/Controllers/BookController.php
## スタイルシート設定追加
public/css/book-index.css
public/scss/book-index.scss
## 複数ISBN登録ビュー作成
resources/views/book/isbn_some.blade.php
## 複数ISBN登録結果ビュー新規作成
resources/views/book/isbn_result.blade.php
## bookメニュー、新規ページ追加
resources/views/components/menu_book.blade.php
## ぱんくずリスト、新規ページ追加
routes/breadcrumbs.php
## 新規作成ページルート追加
routes/web.php

# WHY
複数ISBN一括登録機能を追加
既存の単一コード登録ページとは別で作成として、あたらにビューを作成した。
また、登録結果は別のビューを用意して一覧表示できるようにした。
新規ビュー登録にあたって、周辺のルーティング・メニューへの追加等を実施している。
## 複数ISBN登録に関して
フォーム受け取りデータをISBNコード毎に分けて配列化し、全件未入力時はバリデーションエラーとする。
取得したコードからISBN検索すべき情報を抽出を実施する。桁数誤りや重複登録は全て対象外として処理する。
対象となったISBNコードについてはAPIによる本情報取得を実施。検索できた物に対してはDBへ保存する。
最後に、処理結果を専用ビューにて一覧表示させて完了となる。
## 表示イメージ3/3
入力フォーム 1/3
<img width="1069" alt="スクリーンショット 2019-05-17 15 27 22" src="https://user-images.githubusercontent.com/45278393/57909054-a477a500-78bc-11e9-8922-74a856dff70a.png">
登録結果 2/3
<img width="1064" alt="スクリーンショット 2019-05-17 12 22 00" src="https://user-images.githubusercontent.com/45278393/57909067-aa6d8600-78bc-11e9-83e8-d7e2a3acf799.png">
バリデーションエラー 3/3
<img width="1067" alt="スクリーンショット 2019-05-17 15 29 19" src="https://user-images.githubusercontent.com/45278393/57909077-b22d2a80-78bc-11e9-8074-e94446623b92.png">
