### PR TITLE
複数ISBNコード登録、API検索結果がなかった場合のエラーを解決

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -387,18 +387,17 @@ class BookController extends Controller
             $isbn = $isbnrecords[$i]['isbn'];
             $response = file_get_contents($isbn_url.$isbn);
             $result = json_decode($response, true);
-            data_set($isbnrecords[$i], 'result', $result); // 結果を格納
-            
             // ISBNレコード結果を確認
             // result[0]の情報有り無しで判定
-            if($isbnrecords[$i]['result'][0] == null) {
+            if($result[0] == null) {
               data_set($isbnrecords[$i], 'msg', '該当するISBNコードは見つかりませんでした。'); // 未登録時はメッセージ格納
               data_set($isbnrecords[$i], 'process', 'error'); // 処理ステータスエラー
+            } else {
+              data_set($isbnrecords[$i], 'result', $result); // 結果を格納
             }
           }
         }
 
-        // msgがnullのままの状態の物のみ登録する
         for ($i = 0; $i < $count; $i++){
           if ($isbnrecords[$i]['process'] == 'processing'){ // 処理変数が処理中の場合は処理を実施する
             // ISBNレコードがあれば追加処理

--- a/resources/views/book/isbn_result.blade.php
+++ b/resources/views/book/isbn_result.blade.php
@@ -33,7 +33,7 @@
               <span class="isbn-result__box--isbn">{{$answer['isbn']}}</span>
               <span class="isbn-result__box--msg">{{$answer['msg']}}</span>
             </div>
-            @if (isset($answer['result']))
+            @if ($answer['process'] == 'completion')
             <div class="isbn-result__box--bottom">
               <div class="isbn-result__box--image">
               @if (isset($answer['result']['cover']) == null)

--- a/resources/views/book/isbn_some.blade.php
+++ b/resources/views/book/isbn_some.blade.php
@@ -38,16 +38,6 @@
               @for ($i = 0; $i < 10; $i++)
                 <div><input class="form-input__input" type="number" name="isbn{{$i}}"></div>
               @endfor
-              <!-- <div><input class="form-input__input" type="number" name="isbn0" value="9784797398892"></div>
-              <div><input class="form-input__input" type="number" name="isbn1" value="9784756918765"></div>
-              <div><input class="form-input__input" type="number" name="isbn2" value="9784844366454"></div>
-              <div><input class="form-input__input" type="number" name="isbn3" value="9784798052588"></div>
-              <div><input class="form-input__input" type="number" name="isbn4" value="9784863542174"></div>
-              <div><input class="form-input__input" type="number" name="isbn5" value="9784054066892"></div>
-              <div><input class="form-input__input" type="number" name="isbn6" value="9784756918765"></div>
-              <div><input class="form-input__input" type="number" name="isbn7" value="9784756918765"></div>
-              <div><input class="form-input__input" type="number" name="isbn8" value=""></div>
-              <div><input class="form-input__input" type="number" name="isbn9" value=""></div> -->
             </div>
           </div>
           <div class="form-foot">


### PR DESCRIPTION
# WHAT
API検索結果がなかった場合の処理が正常にできていなかったので修正する
## コントローラ、API取得結果処理を修正
app/Http/Controllers/BookController.php
## 結果表示ビュー、API取得結果表示判断を修正
resources/views/book/isbn_result.blade.php
## ISBN複数登録フォーム、動作確認用に作成していた個別inputフォームを削除
resources/views/book/isbn_some.blade.php

# WHY
## 結果判断による配列データ格納を修正
API検索結果表示の際にresultキーがあれば出力する形としていたが、API検索が実施された場合は書籍情報有無にかかわらずresultキーが生成されていた。
書籍情報がない場合はresultキーは不要であるため処理手順を変更し、書籍情報がある場合のみ生成されるように修正した。
これにより、書籍情報が存在する場合のみ情報が出力されるようになり、エラー解決した。
## ビュー表示判断を修正
上記で問題は解決したが、ビュー画面表示には@if (isset($answer['result']))と記載しており、resultキーがある場合は出力としている。
処理が正常完了した配列には$process=completionという状況が格納されているので、正常完了したデータのみ書籍情報を表示する形に変更した。
