### PR TITLE
ISBN複数登録、テキストエリア対応

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -260,6 +260,10 @@ class BookController extends Controller
       $msg = 'ISBNコードを入力して下さい。';
       return view('book.isbn_some',['msg'=>$msg]);
     }
+    public function getIsbnSomeInput(){
+      $msg = 'ISBNコードを入力して下さい。';
+      return view('book.isbn_some_input',['msg'=>$msg]);
+    }
     public function postIsbn(Request $request){
         // バリデーションチェック
         $this->validate($request, Bookdata::$isbnEntryRules);
@@ -328,16 +332,20 @@ class BookController extends Controller
         // フォームデータ取得
         unset($request['_token']); // トークン削除
         $isbns = $request->all(); // isbnコードをフォームから取得
+        if(array_key_exists('isbns', $isbns)){
+          $data = $isbns['isbns'];
+          $isbns = preg_split("/[\s,]+/", $data);
+        }
         $count = count($isbns); // 取得件数
         $isbnrecords = []; // データ格納用配列
 
         // 処理用配列へ追加
         for ($i = 0; $i < $count; $i++){
-          if ($isbns['isbn'.$i] != null){
+          if ($isbns[$i] != null){
             $isbnrecords[] = array(
               'process' => 'processing',
               'number' => $i+1,
-              'isbn' => $isbns['isbn'.$i],
+              'isbn' => $isbns[$i],
               'msg' => null,
             );
           }

--- a/resources/views/book/isbn_some_input.blade.php
+++ b/resources/views/book/isbn_some_input.blade.php
@@ -34,7 +34,7 @@
           {{ csrf_field() }}
           <div class="form-contents">
             <div class="form-input form-one-size">
-              <div class="form-label">ISBNコード</div>
+              <div class="form-label">ISBNコード[20件まで]（カンマ区切り、改行で連続投入可能）</div>
               <div><textarea class="form-input__detail" type="numbers" name="isbns"></textarea></div>
             </div>
           </div>

--- a/resources/views/book/isbn_some_input.blade.php
+++ b/resources/views/book/isbn_some_input.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.layout')
+
+@section('title', 'ISBN')
+
+@section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('book.isbn_some') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title bookpage-color">
+        ISBNコード登録
+      </div>
+      <div class="books-list__msg">
+        <p class="auth-contents__message--message">{{ $msg }}</p>
+        @foreach ($errors->all() as $error)
+        <p class="auth-contents__message--error">{{ $error }}</p>
+        @endforeach
+      </div>
+      <div class="book-new">
+        <form action="/book/isbn_some" method="post">
+          {{ csrf_field() }}
+          <div class="form-contents">
+            <div class="form-input form-one-size">
+              <div class="form-label">ISBNコード</div>
+              <div><textarea class="form-input__detail" type="numbers" name="isbns"></textarea></div>
+            </div>
+          </div>
+          <div class="form-foot">
+            <input class="send isbn" type="submit" value="登録">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/book/isbn_some_input.blade.php
+++ b/resources/views/book/isbn_some_input.blade.php
@@ -9,7 +9,7 @@
 
 @section('breadcrumbs')
   <div class="book-header__breadcrumbs">
-    {{ Breadcrumbs::render('book.isbn_some') }}
+    {{ Breadcrumbs::render('book.isbn_some_input') }}
   </div>
 @endsection
 

--- a/resources/views/components/menu_book.blade.php
+++ b/resources/views/components/menu_book.blade.php
@@ -19,6 +19,11 @@
       ISBNコード登録(複数)
     </div>
   </a>
+  <a href="/book/isbn_some_input">
+    <div class="tab bookpage-color">
+      ISBNコード登録(一括)
+    </div>
+  </a>
   <a href="/book/find">
     <div class="tab bookpage-color">
       登録書籍検索

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -17,16 +17,22 @@ Breadcrumbs::for('book.create', function ($trail) {
     $trail->push('新規登録', url('book.create'));
 });
 
-// トップページ / 書籍 / ISBN登録(単体)
+// トップページ / 書籍 / ISBN登録
 Breadcrumbs::for('book.isbn', function ($trail) {
     $trail->parent('book.index');
-    $trail->push('ISBN登録(単体)', url('book.isbn'));
+    $trail->push('ISBN登録', url('book.isbn'));
 });
 
 // トップページ / 書籍 / ISBN登録(複数)
 Breadcrumbs::for('book.isbn_some', function ($trail) {
-    $trail->parent('book.index');
-    $trail->push('ISBN登録(複数)', url('book.isbn_some'));
+    $trail->parent('book.isbn');
+    $trail->push('複数登録', url('book.isbn_some'));
+});
+
+// トップページ / 書籍 / ISBN登録(一括)
+Breadcrumbs::for('book.isbn_some_input', function ($trail) {
+    $trail->parent('book.isbn');
+    $trail->push('一括登録', url('book.isbn_some_input'));
 });
 
 // トップページ / 書籍 / 詳細

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::post('/book/isbn', 'BookController@postIsbn');
   Route::get('/book/isbn_some', 'BookController@getIsbnSome');
   Route::post('/book/isbn_some', 'BookController@postIsbnSome');
+  Route::get('/book/isbn_some_input', 'BookController@getIsbnSomeInput');
   Route::get('/book/find', 'BookController@find')->name('book.find');
   Route::post('/book/find', 'BookController@search')->name('book.find');
   Route::resource('book', 'BookController');


### PR DESCRIPTION
# WHAT
テキストエリアフォームを利用して、まとめてISBN登録ができるように対応する
## コントローラー、テキストエリアフォーム対応
app/Http/Controllers/BookController.php
## ビューファイル、テキストエリアフォームを作成
resources/views/book/isbn_some_input.blade.php
## ルーティング、作成フォーム追加
routes/web.php
## メニューリンク追加
resources/views/components/menu_book.blade.php
## ぱんくず設定追加
routes/breadcrumbs.php

# WHY
ISBN複数登録の手段として、textareaによるフォームを追加し、入力内容を分割して一括登録する機能を追加した。
フォーム受け取りデータから「カンマ、空白文字列」を削除して分割することによって、複数の番号を認識させた。
既存のisbn入力フォームとコントローラーを共有するために、設定をみなおした。
判定要素の取り出しに配列のキー名を利用していたが、foreachに変更して要素を順番にとりだすことで、どちらでも評価できるようにした。
ISBNコードについて、ハイフン区切りデータとしてweb上に存在することが多いため、予めプログラム側でハイフンを含む場合は取り除けるようにした。
テキストエリア化に伴い、文字入力も受け付けることとなるため、数値であることの判断要素を追加。
プログラム構造上、上限なく受付できる状態となっているので、上限を20件として設定を追加した。

既存ISBN複数登録フォームコード変更を行っているが、テストにより問題なく動作することを確認している。
今回追加したテキストエリアフォームのテストは別ブランチにて作業を行う

## 表示イメージ
<img width="1067" alt="スクリーンショット 2019-05-19 11 12 40" src="https://user-images.githubusercontent.com/45278393/57977370-11607b80-7a32-11e9-9791-429daf8bc96c.png">