### PR TITLE
本情報削除コード修正

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -191,10 +191,10 @@ class BookController extends Controller
     public function destroy($id)
     {
       $have_property = Property::where('bookdata_id', $id)->first();
-      if (count($have_property) > 0) {
-        $have_book = false;
-      } else {
+      if ($have_property == null) {
         $have_book = true;
+      } else {
+        $have_book = false;
       }
       $validator = Validator::make(['bookdata_id' => $have_book], ['bookdata_id' => 'accepted'], ['所有者がいるため削除できません']);
       if ($validator->fails()) {


### PR DESCRIPTION
# WHAT
デプロイ環境で書籍情報が削除できなくなっていたので、対処を実施

# WHY
所有者がいないかDB確認をした際の結果をcountで件数評価が正常にできていなかったので、値がnullであるかどうかを判定する文に修正した。