### PR TITLE
ISBN一括登録テスト

### DIFF
--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -178,6 +178,39 @@ class BookdataTest extends TestCase
         $savebook = Bookdata::find($bookcount);
         $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
     }
+    // 一括isbn登録と表示確認
+    public function test_someIsbnCommaCreate_ok()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // isbnページアクセス
+        $response = $this->get('/book/isbn_some_input'); // isbnへアクセス
+        $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('book.isbn_some_input'); // book.isbnビューであること
+
+        // 登録
+        $datas = [ 
+            9784756918765,9784844366454,9784798052588,9784863542174,9784822282516,
+            9784054066892,9784046023919,9784046023919,9784797397390,9784023332591,
+        ]; // 登録用データ
+        $isbns = implode(",", $datas); // フォーム入力用一括登録テキスト（カンマ区切り）
+        $inputform = ['isbns' => $isbns]; // フォーム送信用データ生成
+        $response = $this->from('book/isbn_some')->post('book/isbn_some', $inputform); // フォームよりpost送信
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+
+        $response->assertSeeText('ISBNコード登録結果'); // 登録結果ページが出力されていること
+        foreach($datas as $data){
+            $response->assertSeeText($data); // 入力番号が反映されていること
+        }
+        $savebooks = Bookdata::all();
+        foreach($savebooks as $savebook){
+            $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
+        }
+    }
     // 検索
     public function test_findTitle_ok_yesMatchFindTitle()
     {

--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -211,7 +211,54 @@ class BookdataTest extends TestCase
             $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
         }
     }
-    // 検索
+    // 一括isbn登録、ハイフン解除確認
+    public function test_someIsbnCommaHyphenCreate_ok()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // 登録
+        $testisbn = '978-4756918765'; // テスト用ISBNコード
+        $inputform = ['isbns' => $testisbn]; // フォーム送信用データ生成
+        $response = $this->from('book/isbn_some')->post('book/isbn_some', $inputform); // フォームよりpost送信
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+
+        $response->assertSeeText('ISBNコード登録結果'); // 登録結果ページが出力されていること
+        $data = str_replace('-', '', $testisbn); // 表示確認コード生成、ハイフンを取り除く
+        $response->assertSeeText($data); // 入力番号が反映されていること
+        $savebook = Bookdata::first();
+        // eval(\Psy\sh());
+        $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
+    }
+    // 一括isbn登録、空文字削除対応確認
+    public function test_someIsbnCommaSpaceCreate_ok()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // 登録
+        $testisbn = 
+            "9784756918765\n9784844366454"; // テスト用ISBNコード
+        $inputform = ['isbns' => $testisbn]; // フォーム送信用データ生成
+        $response = $this->from('book/isbn_some')->post('book/isbn_some', $inputform); // フォームよりpost送信
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+
+        $response->assertSeeText('ISBNコード登録結果'); // 登録結果ページが出力されていること
+        $datas = preg_split("/[\s,]+/", $testisbn); // 確認用データを抽出
+        foreach ($datas as $data){
+            $response->assertSeeText($data); // 入力番号が反映されていること
+        }
+        $savebooks = Bookdata::all();
+        foreach($savebooks as $savebook){
+            $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
+        }
+    }    // 検索
     public function test_findTitle_ok_yesMatchFindTitle()
     {
         //// ユーザー生成


### PR DESCRIPTION
# WHAT
ISBN一括登録機能テストを実施する
tests/Feature/BookdataTest.php

# WHY
## 正常とする処理テスト
ISBN一括登録機能を追加したことによる、機能追加ポイントに対してテストを実施した。
複数件登録テキストによる登録を実施し、全件のISBN番号及びAPIによる取得タイトルが表示されていることを確認。
半角ハイフン含むコードについて、ハイフンを取り除き13桁数値として正常に取得タイトルが表示されていることを確認。
## 異常とする処理テスト
全件入力項目空欄時にバリデーションによるエラーとして処理し元の画面へリダイレクト処理されることの確認。
予め指定した上限を超過するISBNについては処理されていないことを確認。具体的には、超過コードについて結果画面にも出力されないこと。
数値以外の入力データに対して数値でない旨のエラーが返されること。
