### PR TITLE
書籍情報複数削除機能

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -454,9 +454,8 @@ class BookController extends Controller
     public function someDelete(Request $request){
       // フォームデータ取得
       unset($request['_token']); // トークン削除
-      $datas = $request->input('select_book'); // 削除書籍情報をフォームから取得
+      $datas = $request->input('select_books'); // 削除書籍情報をフォームから取得
       $count = count($datas); // 取得件数
-
       // 取得データなければ処理中止
       if ($count == 0) {
         // 削除情報が1件もないときはバリデーションエラーにする

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -451,7 +451,7 @@ class BookController extends Controller
         return view('book.isbn_result',['answers' => $isbnrecords]);
     }
 
-    public function somedelete(Request $request){
+    public function someDelete(Request $request){
       // フォームデータ取得
       unset($request['_token']); // トークン削除
       $datas = $request->input('select_book'); // 削除書籍情報をフォームから取得

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -454,9 +454,8 @@ class BookController extends Controller
     public function somedelete(Request $request){
       // フォームデータ取得
       unset($request['_token']); // トークン削除
-      $datas = $request->all(); // 削除書籍情報をフォームから取得
+      $datas = $request->input('select_book'); // 削除書籍情報をフォームから取得
       $count = count($datas); // 取得件数
-      $datas = array_keys($datas);
 
       // 取得データなければ処理中止
       if ($count == 0) {

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -184,9 +184,8 @@ class PropertyController extends Controller
     public function somedelete(Request $request){
       // フォームデータ取得
       unset($request['_token']); // トークン削除
-      $datas = $request->all(); // 削除所有書籍情報をフォームから取得
+      $datas = $request->input('select_book'); // 削除書籍情報をフォームから取得
       $count = count($datas); // 取得件数
-      $datas = array_keys($datas);
 
       // 取得データなければ処理中止
       if ($count == 0) {

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -184,7 +184,7 @@ class PropertyController extends Controller
     public function somedelete(Request $request){
       // フォームデータ取得
       unset($request['_token']); // トークン削除
-      $datas = $request->input('select_book'); // 削除書籍情報をフォームから取得
+      $datas = $request->input('select_books'); // 削除書籍情報をフォームから取得
       $count = count($datas); // 取得件数
 
       // 取得データなければ処理中止

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -64,16 +64,23 @@
   padding: 0;
 }
 .index-content .books-list .book-table {
-  margin-top: 30px;
   font-size: 14px;
   width: 800px;
-  border-top: 1px solid #5ba5c8;
 }
 .index-content .books-list .book-table__list {
   height: 90px;
   padding: 10px 5px;
-  border-bottom: 1px solid #5ba5c8;
+  border-top: 1px solid #5ba5c8;
   display: flex;
+}
+.index-content .books-list .book-table__list--checkbox {
+  display: flex;
+  /*上下中央揃え*/
+  align-items: center;
+  margin-right: 10px;
+}
+.index-content .books-list .book-table__list--checkbox input[type=checkbox] {
+  transform: scale(2);
 }
 .index-content .books-list .book-table__list--picture {
   height: 90px;
@@ -109,6 +116,12 @@
 }
 .index-content .books-list .book-table__profile-list .profile-group__edit a {
   color: blue;
+}
+.index-content .books-list .book-table__btn {
+  margin: 10px 0;
+}
+.index-content .books-list .book-table__btn--delete {
+  color: red;
 }
 .index-content .books-list .book-detail {
   width: 100%;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -62,15 +62,23 @@
       }
     }
     .book-table {
-      margin-top: 30px;
+      // margin-top: 30px;
       font-size: 14px;
       width: 800px;
-      border-top: 1px solid #5ba5c8;
       &__list {
         height: 90px;
         padding: 10px 5px;
-        border-bottom: 1px solid #5ba5c8;
+        border-top: 1px solid #5ba5c8;
         display: flex;
+        &--checkbox {
+          display: flex;
+          /*上下中央揃え*/
+          align-items: center;
+          margin-right: 10px;
+          input[type=checkbox] {
+            transform: scale(2);
+          }
+        }  
         &--picture {
           height: 90px;
           width: 90px;
@@ -111,12 +119,18 @@
           }
         }
       }
+      &__btn {
+        margin: 10px 0;
+        &--delete {
+          color: red;
+        }
+      }
     }
     .book-detail {
       width: 100%;
       display: flex;
       margin-top: 15px;
-      &__picture{
+      &__picture {
         img {
           height: 200px;
           width: 200px;

--- a/resources/views/book/delete_result.blade.php
+++ b/resources/views/book/delete_result.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.layout')
+
+@section('title', 'SomeBooksDelete')
+
+@section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('book.isbn_some') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_book')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title bookpage-color">
+        書籍削除結果
+      </div>
+
+      <div class="isbn-result">
+        @foreach ($answers as $answer)
+        <div class="isbn-result__box">
+          <div class="isbn-result__box--number">{{$answer['number']}}</div>
+          <div class="isbn-result__box--detail">
+            <div class="isbn-result__box--head">
+              <span class="isbn-result__box--isbn">{{$answer['title']}}</span>
+              <span class="isbn-result__box--msg">{{$answer['msg']}}</span>
+            </div>
+            @if ($answer['process'] == 'completion')
+            <div class="isbn-result__box--bottom">
+            </div>
+            @endif
+          </div>
+        </div>
+        @endforeach
+
+    </div>
+  </div>
+@endsection

--- a/resources/views/book/delete_result.blade.php
+++ b/resources/views/book/delete_result.blade.php
@@ -33,10 +33,6 @@
               <span class="isbn-result__box--isbn">{{$answer['title']}}</span>
               <span class="isbn-result__box--msg">{{$answer['msg']}}</span>
             </div>
-            @if ($answer['process'] == 'completion')
-            <div class="isbn-result__box--bottom">
-            </div>
-            @endif
           </div>
         </div>
         @endforeach

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -13,7 +13,7 @@
       @foreach ($books as $book)
         <div class="book-table__list">
           <div class="book-table__list--checkbox">
-            <input type="checkbox" name="{{$book->id}}">
+            <input type="checkbox" name="select_book[]" value="{{$book->id}}">
           </div>
           <div class="book-table__list--picture">
             <a href="/{{$page_path}}/{{$book->id}}">

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -1,23 +1,37 @@
 <div class="book-table">
   @if (isset($books))
-    @foreach ($books as $book)
-      <div class="book-table__list">
-        <div class="book-table__list--picture">
-          <a href="/{{$page_path}}/{{$book->id}}">
-            @if (isset($book->picture))
-              <img src="{{$book->picture}}">
-            @elseif (isset($book->cover))
-              <img src="{{$book->cover}}">
-            @else
-              <img src="../image/no-entry.jpg">
-            @endif
-          </a>
-        </div>
-        <div class="book-table__list--detail">
-          <a href="/{{$page_path}}/{{$book->id}}"><h3 class="list-book-title">{{$book->title}}</h3></a>
-          <p class="list-book-detail">{{ str_limit($book->$detail, $limit = 300, $end = '...') }}</p>
-        </div>
+    @if ($page_path == 'book')
+      <form action="{{ route('book.some_delete') }}" method="post">
+    @else
+      <form action="{{ route('property.some_delete') }}" method="post">
+    @endif
+      <div class="book-table__btn">
+        <span>操作：</span>
+        <input type="submit" class="book-table__btn--delete" value="書籍情報一括削除">
       </div>
-    @endforeach
+      {{ csrf_field() }}
+      @foreach ($books as $book)
+        <div class="book-table__list">
+          <div class="book-table__list--checkbox">
+            <input type="checkbox" name="{{$book->id}}">
+          </div>
+          <div class="book-table__list--picture">
+            <a href="/{{$page_path}}/{{$book->id}}">
+              @if (isset($book->picture))
+                <img src="{{$book->picture}}">
+              @elseif (isset($book->cover))
+                <img src="{{$book->cover}}">
+              @else
+                <img src="../image/no-entry.jpg">
+              @endif
+            </a>
+          </div>
+          <div class="book-table__list--detail">
+            <a href="/{{$page_path}}/{{$book->id}}"><h3 class="list-book-title">{{$book->title}}</h3></a>
+            <p class="list-book-detail">{{ str_limit($book->$detail, $limit = 300, $end = '...') }}</p>
+          </div>
+        </div>
+      @endforeach
+    </form>
   @endif
 </div>

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -13,7 +13,7 @@
       @foreach ($books as $book)
         <div class="book-table__list">
           <div class="book-table__list--checkbox">
-            <input type="checkbox" name="select_book[]" value="{{$book->id}}">
+            <input type="checkbox" name="select_books[]" value="{{$book->id}}">
           </div>
           <div class="book-table__list--picture">
             <a href="/{{$page_path}}/{{$book->id}}">

--- a/resources/views/property/delete_result.blade.php
+++ b/resources/views/property/delete_result.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.layout')
+
+@section('title', 'SomePropertiesDelete')
+
+@section('stylesheet')
+<link href="/css/menulist.css" rel="stylesheet" type="text/css">
+  <link href="/css/book-index.css" rel="stylesheet" type="text/css">
+@endsection
+
+@section('breadcrumbs')
+  <div class="book-header__breadcrumbs">
+    {{ Breadcrumbs::render('book.isbn_some') }}
+  </div>
+@endsection
+
+@section('pagemenu')
+  @include('components.menu_property')
+@endsection
+
+@section('content')
+  <div class="index-content">
+    <div class="books-list">
+      <div class="books-list__title propertypage-color">
+        所有書籍情報解除結果
+      </div>
+
+      <div class="isbn-result">
+        @foreach ($answers as $answer)
+        <div class="isbn-result__box">
+          <div class="isbn-result__box--number">{{$answer['number']}}</div>
+          <div class="isbn-result__box--detail">
+            <div class="isbn-result__box--head">
+              <span class="isbn-result__box--isbn">{{$answer['title']}}</span>
+              <span class="isbn-result__box--msg">{{$answer['msg']}}</span>
+            </div>
+            @if ($answer['process'] == 'completion')
+            <div class="isbn-result__box--bottom">
+            </div>
+            @endif
+          </div>
+        </div>
+        @endforeach
+
+    </div>
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::resource('book', 'BookController');
   Route::get('/property/find', 'PropertyController@find')->name('property.find');
   Route::post('/property/find', 'PropertyController@search')->name('property.find');
-  Route::post('/property/somedelete', 'PropertyController@somedelete')->name('property.some_delete');
+  Route::post('/property/somedelete', 'PropertyController@someDelete')->name('property.some_delete');
   Route::resource('property', 'PropertyController');
   Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');
   Route::post('/user/email', 'UserController@userEmailChange')->name('email.change');

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,9 +28,11 @@ Route::group(['middleware' => ['verified']], function () {
   Route::get('/book/isbn_some_input', 'BookController@getIsbnSomeInput');
   Route::get('/book/find', 'BookController@find')->name('book.find');
   Route::post('/book/find', 'BookController@search')->name('book.find');
+  Route::post('/book/somedelete', 'BookController@somedelete')->name('book.some_delete');
   Route::resource('book', 'BookController');
   Route::get('/property/find', 'PropertyController@find')->name('property.find');
   Route::post('/property/find', 'PropertyController@search')->name('property.find');
+  Route::post('/property/somedelete', 'PropertyController@somedelete')->name('property.some_delete');
   Route::resource('property', 'PropertyController');
   Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');
   Route::post('/user/email', 'UserController@userEmailChange')->name('email.change');


### PR DESCRIPTION
# WHAT
登録書籍情報を複数まとめて削除できる機能を実装する
書籍情報一覧より選択して削除する機能として実装
同じ書籍情報一覧を利用している所有書籍情報解除もあわせて実装する
## コントローラ、書籍情報削除アクション作成
app/Http/Controllers/BookController.php
app/Http/Controllers/PropertyController.php
## スタイルシート、削除コンテンツスタイル指定
public/css/book-index.css
public/scss/book-index.scss
## ビュー、一括削除結果表示
resources/views/book/delete_result.blade.php
resources/views/property/delete_result.blade.php
resources/views/components/books_list.blade.php
## ルーティング、新規ビュー情報追加
routes/web.php

# WHY
書籍情報一括削除を実施する為に、一覧表示コンポーネントにチェックボックス欄を追加。
コンポーネント編集に伴い、book.index、book.find、property.index、property.findに反映されるため、それぞれに対応するアクションとして動作させる。
bookでは書籍情報削除、propertyでは所有書籍情報の解除として設定。
スロットによって呼び出し先を変更できるようにしており、それを利用してフォームの呼び出し先を変更している。
<img width="1073" alt="スクリーンショット 2019-05-24 13 51 40" src="https://user-images.githubusercontent.com/45278393/58378136-64ee3e80-7fc9-11e9-842f-5effcdb83293.png">
