### PR TITLE
複数書籍削除テスト

### DIFF
--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -307,7 +307,34 @@ class BookdataTest extends TestCase
         $response->assertViewIs('book.find'); // book.findビューであること
         $response->assertSeeText('書籍がみつかりませんでした。'); // タイトルなしメッセージが表示されていること
     }
+     // 複数削除
+     public function test_bookControll_ok_someDelete()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
 
+        // faker 自動生成
+        $delete_bookdatas = factory(Bookdata::class, 20)->create();
+        // 送信フォームパス
+        $formpath = 'book/somedelete';
+        // 削除データ
+        $deletedata = ['select_books' => range(1, 20)];
+
+        //// 削除
+        $response = $this->from($formpath)->post($formpath, $deletedata); // 削除実施
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('book.delete_result'); // book.delete_resultビューであること
+
+        // 削除されていることの確認(resultページ)
+        $response->assertSeeText('書籍削除結果'); // 削除結果ページが出力されていること
+        $response->assertStatus(200); // 200ステータスであること
+        foreach($delete_bookdatas as $deletebook){
+            $response->assertSeeText($deletebook->title); // 削除タイトルが結果に反映されていること
+        }
+    }
 
     //// NGパターン調査
     // 手動登録タイトル未入力

--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -259,7 +259,7 @@ class BookdataTest extends TestCase
             $response->assertSeeText($savebook->title); // 取得した本のタイトルがが反映されていること
         }
     }
-    // 検索
+    // 検索書籍有り
     public function test_findTitle_ok_yesMatchFindTitle()
     {
         //// ユーザー生成
@@ -282,6 +282,7 @@ class BookdataTest extends TestCase
         $response->assertStatus(200); // 200ステータスであること
         $response->assertSeeText($bookdata->title); // bookdataタイトルが表示されていること
     }
+    // 検索書籍なし
     public function test_findTitle_ok_noMatchFindTitle()
     {
         //// ユーザー生成

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -200,7 +200,37 @@ class PropertyTest extends TestCase
             $response->assertSeeText($savebook->bookdata->title);
         } // 登録タイトルが表示されていること
     }
+     // 複数削除
+     public function test_propertySomeControll_ok_someDelete()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
 
+        // faker 自動生成
+        $delete_propertydatas = factory(Property::class, 20)->create([
+            'user_id' => $user->id,
+        ]);
+
+        // 送信フォームパス
+        $formpath = 'property/somedelete';
+        // 削除データ
+        $deletedatas = ['select_books' => range(1, 20)];
+
+        //// 削除
+        $response = $this->from($formpath)->post($formpath, $deletedatas); // 削除実施
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('property.delete_result'); // property.delete_resultビューであること
+
+        // 削除されていることの確認(resultページ)
+        $response->assertSeeText('所有書籍情報解除結果'); // 削除結果ページが出力されていること
+        $response->assertStatus(200); // 200ステータスであること
+        foreach($delete_propertydatas as $deleteproperty){
+            $response->assertSeeText($deleteproperty->bookdata->title); // 削除タイトルが結果に反映されていること
+        }
+    }
 
     //// NGパターン調査
     // タイトル未入力

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -473,4 +473,78 @@ class PropertyTest extends TestCase
         $savebook = Property::find(11);
         $response->assertDontSeeText($savebook->bookdata->title); // 登録タイトルが表示されていないこと
     }
+    // 複数削除エラー、postデータなし
+    public function test_propertyControll_ng_someDeleteNotEntry()
+    {
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // 送信フォームパス
+        $formpath = 'property/somedelete';
+        // 削除データ
+        $deletedata = [];
+
+        //// 削除
+        $response = $this->from($formpath)->post($formpath, $deletedata); // 削除実施
+        $response->assertSessionHasErrors(); // エラーメッセージがあること
+        $response->assertStatus(302); // リダイレクト
+        $response->assertRedirect('property'); // propertyビューであること
+        $this->assertEquals('所有書籍から解除する本が選択されていません',
+        session('errors')->first('deleteproperty')); // エラメッセージを確認
+    }
+     // 複数削除エラー、上限超過処理
+     public function test_propertyControll_ng_someDeleteLimitNumber()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        $count = 20;// 上限設定
+        // faker 自動生成
+        $delete_propertydatas = factory(Property::class, $count+1)->create([
+            'user_id' => $user->id,
+        ]);
+
+        // 送信フォームパス
+        $formpath = 'property/somedelete';
+        // 削除データ
+        $deletedata = ['select_books' => range(1, 20)];
+
+        //// 削除
+        $response = $this->from($formpath)->post($formpath, $deletedata); // 削除実施
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(200); // 200ステータスであること
+
+        $response->assertSeeText('所有書籍情報解除結果'); // 登録結果ページが出力されていること
+        // 編集ISBN番号結果確認
+        for ($i = 0; $i < $count+1; $i++){
+            if ($count > $i){ // 上限数まで結果表示されること
+                $response->assertSeeText($delete_propertydatas[$i]->bookdata->title); // タイトルが反映されていること
+            } else { // 上限超過データは扱われていないこと
+                $response->assertDontSeeText($delete_propertydatas[$i]->bookdata->title); // タイトルが反映されていないこと
+            }
+        }
+    }
+     // 複数削除エラー、他者データ削除
+     public function test_bookControll_ng_someDeleteOtherHaveProperty()
+    {
+        //// ユーザー生成
+        $user = factory(User::class)->create(); // ユーザーを作成
+        $this->actingAs($user); // ログイン済み
+        $this->assertTrue(Auth::check()); // Auth認証済であることを確認
+
+        // faker 自動生成
+        $delete_bookdata = factory(Property::class)->create();
+        // 送信フォームパス
+        $formpath = 'property/somedelete';
+        // 削除データ
+        $deletedata = ['select_books' => [$delete_bookdata->id]];
+
+        //// 削除
+        $response = $this->from($formpath)->post($formpath, $deletedata); // 削除実施
+        $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
+        $response->assertStatus(500); // 500ステータスであること
+    }
 }


### PR DESCRIPTION
# WHAT
複数書籍削除機能のテストを行い、問題なく動作することを確認する。
## テストコード記述
tests/Feature/BookdataTest.php
tests/Feature/PropertyTest.php

# WHY
複数登録された書籍の削除及び、複数の所持書籍情報から所有状態を解除する機能についてのテストを実施。
正常に削除できる処理についてのテストを実施。
削除時に選択データがなかった場合についてのバリデーションによるエラー処理が行えていることの確認。
削除上限超過時の処理が正常に行えていることの確認。
書籍所有者がいる場合に書籍情報が削除てきないことを確認。
他人の所有書籍情報が削除できないことを確認。
