### PR TITLE
ページネーション実装

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -17,7 +17,7 @@ class BookController extends Controller
      */
     public function index()
     {
-        $books = Bookdata::all();
+        $books = Bookdata::paginate(20);
         return view('book.index', ['books' => $books]);
     }
 
@@ -241,12 +241,12 @@ class BookController extends Controller
       // バリデーションチェック
       $this->validate($request, Bookdata::$searchRules);
       $title = $request->find;
-      $books = Bookdata::where('title', 'like', "%{$title}%")->get();
+      $books = Bookdata::where('title', 'like', "%{$title}%")->paginate(20);
       $count = count($books);
       if ($count==0) {
         $msg = '書籍がみつかりませんでした。';
       } else {
-        $msg = $count.'件の書籍がみつかりました。';
+        $msg = $books->total().'件の書籍がみつかりました。';
       }
       $param = ['input' => $title, 'books' => $books, 'msg' => $msg];
       return view('book.find', $param);

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -171,12 +171,12 @@ class PropertyController extends Controller
                         ->join('bookdata','bookdata.id','=','properties.bookdata_id')
                         ->where('title', 'like', "%{$title}%")
                         ->select('properties.id','title','picture','cover','freememo')
-                        ->get();
+                        ->paginate(20);
       $count = count($properties);
       if ($count==0) {
         $msg = '書籍がみつかりませんでした。';
       } else {
-        $msg = $count.'件の書籍がみつかりました。';
+        $msg = $properties->total().'件の書籍がみつかりました。';
       }
       $param = ['input' => $title, 'books' => $properties, 'msg' => $msg];
       return view('property.find', $param);

--- a/app/Property.php
+++ b/app/Property.php
@@ -25,7 +25,7 @@ class Property extends Model
       $property = Property::where('user_id', Auth::user()->id)
                       ->join('bookdata','bookdata.id','=','properties.bookdata_id')
                       ->select('properties.id','title','picture','cover','freememo')
-                      ->get();
+                      ->paginate(20);
       return $property;
   }
   public function scopeUserNothaveBook()

--- a/app/Providers/UserServiceProvider.php
+++ b/app/Providers/UserServiceProvider.php
@@ -30,8 +30,8 @@ class UserServiceProvider extends ServiceProvider
             'components.user_nav', function($view) {
                 $view->with([
                     'name' => Auth::user()->name,
-                    'user_book_count'=> count(Property::userGetBook()),
-                ]);
+                    'user_book_count'=> Property::userGetBook()->total(),
+                    ]);
             }
         );
     }

--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -67,6 +67,24 @@
   font-size: 14px;
   width: 800px;
 }
+.index-content .books-list .book-table .pagination {
+  display: flex;
+  justify-content: center;
+  margin: 20px;
+}
+.index-content .books-list .book-table .pagination .page-item {
+  border: 0.5px solid #eee;
+  padding: 15px;
+}
+.index-content .books-list .book-table .pagination .disabled {
+  color: #222;
+}
+.index-content .books-list .book-table .pagination .active {
+  background: #7dc7ea;
+}
+.index-content .books-list .book-table .pagination .page-link {
+  color: #999;
+}
 .index-content .books-list .book-table__list {
   height: 90px;
   padding: 10px 5px;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -65,6 +65,24 @@
       // margin-top: 30px;
       font-size: 14px;
       width: 800px;
+      .pagination {
+        display: flex;
+        justify-content: center; 
+        margin: 20px;
+        .page-item {
+          border: 0.5px solid #eeeeee;
+          padding: 15px;
+        }
+        .disabled {
+          color: #222222;
+        }
+        .active {
+          background: #7dc7ea;
+        }
+        .page-link {
+          color: #999999;
+        }
+      }
       &__list {
         height: 90px;
         padding: 10px 5px;

--- a/resources/views/book/find.blade.php
+++ b/resources/views/book/find.blade.php
@@ -43,9 +43,6 @@
           @slot('detail')
             detail
           @endslot
-          @slot('pagination')
-            find
-          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/book/find.blade.php
+++ b/resources/views/book/find.blade.php
@@ -29,8 +29,7 @@
         <p class="auth-contents__message--error">{{ $error }}</p>
         @endforeach
       </div>
-      <form class="book-find" action="{{ route('book.find') }}" method="post">
-        {{ csrf_field() }}
+      <form class="book-find" action="{{ route('book.search') }}" method="get">
         <div class="book-find__input">
           <input type="text" class="book-find__input--text" name="find" value="{{$input}}">
           <input type="submit" class="book-find__input--submit" value="検索">
@@ -43,6 +42,9 @@
           @endslot
           @slot('detail')
             detail
+          @endslot
+          @slot('pagination')
+            find
           @endslot
         @endcomponent
       @endif

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -31,9 +31,6 @@
           @slot('detail')
             detail
           @endslot
-          @slot('pagination')
-            index
-          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/book/index.blade.php
+++ b/resources/views/book/index.blade.php
@@ -31,6 +31,9 @@
           @slot('detail')
             detail
           @endslot
+          @slot('pagination')
+            index
+          @endslot
         @endcomponent
       @endif
     </div>

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -5,6 +5,11 @@
     @else
       <form action="{{ route('property.some_delete') }}" method="post">
     @endif
+    @if ($pagination == 'index')
+      {{ $books->links() }}
+    @elseif ($pagination == 'find')
+      {{ $books->appends(Request::only('find'))->links() }}
+    @endif
       <div class="book-table__btn">
         <span>操作：</span>
         <input type="submit" class="book-table__btn--delete" value="書籍情報一括削除">
@@ -33,5 +38,10 @@
         </div>
       @endforeach
     </form>
+    @if ($pagination == 'index')
+      {{ $books->links() }}
+    @elseif ($pagination == 'find')
+      {{ $books->appends(Request::only('find'))->links() }}
+    @endif
   @endif
 </div>

--- a/resources/views/components/books_list.blade.php
+++ b/resources/views/components/books_list.blade.php
@@ -5,11 +5,7 @@
     @else
       <form action="{{ route('property.some_delete') }}" method="post">
     @endif
-    @if ($pagination == 'index')
-      {{ $books->links() }}
-    @elseif ($pagination == 'find')
       {{ $books->appends(Request::only('find'))->links() }}
-    @endif
       <div class="book-table__btn">
         <span>操作：</span>
         <input type="submit" class="book-table__btn--delete" value="書籍情報一括削除">
@@ -38,10 +34,6 @@
         </div>
       @endforeach
     </form>
-    @if ($pagination == 'index')
-      {{ $books->links() }}
-    @elseif ($pagination == 'find')
       {{ $books->appends(Request::only('find'))->links() }}
-    @endif
   @endif
 </div>

--- a/resources/views/property/find.blade.php
+++ b/resources/views/property/find.blade.php
@@ -29,8 +29,7 @@
         <p class="auth-contents__message--error">{{ $error }}</p>
         @endforeach
       </div>
-      <form class="book-find" action="{{ route('property.find') }}" method="post">
-        {{ csrf_field() }}
+      <form class="book-find" action="{{ route('property.search') }}" method="get">
         <div class="book-find__input">
           <input type="text" class="book-find__input--text" name="find" value="{{$input}}">
           <input type="submit" class="book-find__input--submit" value="検索">

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::post('/book/somedelete', 'BookController@somedelete')->name('book.some_delete');
   Route::resource('book', 'BookController');
   Route::get('/property/find', 'PropertyController@find')->name('property.find');
-  Route::post('/property/find', 'PropertyController@search')->name('property.find');
+  Route::get('/property/search', 'PropertyController@search')->name('property.search');
   Route::post('/property/somedelete', 'PropertyController@someDelete')->name('property.some_delete');
   Route::resource('property', 'PropertyController');
   Route::get('/user/email', 'UserController@userEmailEdit')->name('email.edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ Route::group(['middleware' => ['verified']], function () {
   Route::post('/book/isbn_some', 'BookController@postIsbnSome');
   Route::get('/book/isbn_some_input', 'BookController@getIsbnSomeInput');
   Route::get('/book/find', 'BookController@find')->name('book.find');
-  Route::post('/book/find', 'BookController@search')->name('book.find');
+  Route::get('/book/search', 'BookController@search')->name('book.search');
   Route::post('/book/somedelete', 'BookController@somedelete')->name('book.some_delete');
   Route::resource('book', 'BookController');
   Route::get('/property/find', 'PropertyController@find')->name('property.find');

--- a/tests/Feature/BookdataTest.php
+++ b/tests/Feature/BookdataTest.php
@@ -269,17 +269,15 @@ class BookdataTest extends TestCase
 
         // faker book自動生成
         $bookdata = factory(Bookdata::class)->create();
-
-        //// 検索
-        // 検索の実施(findページ)
+        // 検索
         $find_post = 'book/find'; // 検索パス
-        $savebook = Bookdata::all()->first(); // 保存されたデータを取得
         $response = $this->get($find_post); // 検索ページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('book.find'); // book.findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => $bookdata->title]); // 検索実施
+        $response = $this->call('GET', 'book/search', ['find' => $bookdata->title]); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200ステータスであること
+        $response->assertViewIs('book.find'); // book.findビューであること
         $response->assertSeeText($bookdata->title); // bookdataタイトルが表示されていること
     }
     // 検索書籍なし
@@ -302,7 +300,7 @@ class BookdataTest extends TestCase
         $response = $this->get($find_post); // 検索ページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('book.find'); // book.findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => 'b']); // bで検索実施
+        $response = $this->call('GET', 'book/search', ['find' => 'b']); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200 ステータスであること
         $response->assertViewIs('book.find'); // book.findビューであること
@@ -525,7 +523,7 @@ class BookdataTest extends TestCase
         $response = $this->get($find_post); // 検索ページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('book.find'); // book.findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => '']); // 検索実施
+        $response = $this->call('GET', 'book/search', ['find' => '']); // 検索実施
         $response->assertSessionHasErrors('find'); // エラーメッセージがあること
         $response->assertStatus(302); // リダイレクト
         $response->assertRedirect('book/find');  // 同ページへリダイレクト

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -134,7 +134,7 @@ class PropertyTest extends TestCase
         $response = $this->get($find_post); // findページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('property.find'); // findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => $propertydata->bookdata->title]); // 検索実施
+        $response = $this->call('GET', 'property/search', ['find' => $bookdata->title]); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200ステータスであること
         $response->assertSeeText($propertydata->bookdata->title); // findタイトルが表示されていること
@@ -158,7 +158,7 @@ class PropertyTest extends TestCase
         $response = $this->get($find_post); // findページへアクセス
         $response->assertStatus(200); // 200ステータスであること
         $response->assertViewIs('property.find'); // findビューであること
-        $response = $this->from($find_post)->post($find_post, ['find' => 'b']); // 指定タイトル名で検索実施
+        $response = $this->call('GET', 'property/search', ['find' => 'b']); // 検索実施
         $response->assertSessionHasNoErrors(); // エラーメッセージがないこと
         $response->assertStatus(200); // 200 ステータスであること
         $response->assertViewIs('property.find'); // findビューであること


### PR DESCRIPTION
# WHAT
bookdataページにページネーション機能を実装し、リスト表示内で上限を超えるデータは次ページに表示できるようにする。
## コントローラ、ページネーション付与
app/Http/Controllers/BookController.php
app/Http/Controllers/PropertyController.php
## モデル、ページネーション付与
app/Property.php
## プロバイダ、ユーザー所持総件数表示修正
app/Providers/UserServiceProvider.php
## ページネーションスタイル設定
public/css/book-index.css
public/scss/book-index.scss
## ビュー
### 検索フォーム、ルート変更
resources/views/book/find.blade.php
resources/views/property/find.blade.php
### ページネーション、ナビ追加
resources/views/components/books_list.blade.php
## ルーティング、メソッド変更
routes/web.php
## テスト、検索メソッド変更に伴うメソッド変更
tests/Feature/BookdataTest.php
tests/Feature/PropertyTest.php

# WHY
書籍情報ページ及び所有書籍ページにて以下の対応を実施
コンポーネント表示リストに対してページネーション表示を実装。
コンポーネント表示はindexリスト及び検索結果にも対応となる。
検索結果対応の為のURL標記がpostメソッドでは対応できないので、getメソッドに変更。
メソッド変更に伴うフォーム及びテストの修正を実施。
