### PR TITLE
IE表示崩れに伴う、スタイルシート修正

### DIFF
--- a/public/css/book-index.css
+++ b/public/css/book-index.css
@@ -102,7 +102,6 @@
 }
 .index-content .books-list .book-table__list--picture {
   height: 90px;
-  width: 90px;
 }
 .index-content .books-list .book-table__list--picture img {
   height: 90px;

--- a/public/scss/book-index.scss
+++ b/public/scss/book-index.scss
@@ -99,7 +99,6 @@
         }  
         &--picture {
           height: 90px;
-          width: 90px;
           img {
             height: 90px;
             width: 90px;


### PR DESCRIPTION
# WHAT
Windows7+IE11で表示時に一覧表示にて画像の上にテキストが表示されていた為に、スタイルシート調整を実施する。

# WHY
![Win-index09](https://user-images.githubusercontent.com/45278393/58682714-9f325400-83ac-11e9-872f-b3313b8fa888.JPG)
画像表示エリアを囲うclassに対してのwidth設定を削除することで、重複していたデータ表示を解消。
chromeによる正常表示データの表示崩れもないため、本修正にて対処とする。